### PR TITLE
fix additional corpus text file not being copied to model

### DIFF
--- a/elpis/wrappers/input/json_to_kaldi.py
+++ b/elpis/wrappers/input/json_to_kaldi.py
@@ -249,7 +249,7 @@ def create_kaldi_structure(input_json: str,
         only_text = []
         for file_ in all_files_in_dir:
             file_name, extension = os.path.splitext(file_)
-            print(f"file {file_name}")
+            print(f"file {file_name} {extension}")
             if extension == ".txt":
                 only_text.append(file_)
         for corpora_file in only_text:

--- a/elpis/wrappers/objects/model.py
+++ b/elpis/wrappers/objects/model.py
@@ -64,8 +64,15 @@ class Model(FSObject):  # TODO not thread safe
         # task json-to-kaldi
         output_path = self.path.joinpath('output')
         output_path.mkdir(parents=True, exist_ok=True)
+        # gui only handles one corpus file of extra words for language model training
+        # because it is matching explicilty on a filename (corpus.txt)
+        # but create_kaldi_structure can read content from multiple files in the model/XX/text_corpus dir
+        original_text_corpus_path = self.dataset.path.joinpath('original', 'corpus.txt')
         text_corpus_path = self.path.joinpath('text_corpus')
         text_corpus_path.mkdir(parents=True, exist_ok=True)
+        if os.path.exists(original_text_corpus_path):
+            shutil.copy(f"{original_text_corpus_path}", f"{text_corpus_path}")
+        # content from uploaded corpus file(s) will be written to file at corpus_file_path
         corpus_file_path = self.path.joinpath('corpus.txt')
         create_kaldi_structure(
             input_json=f'{self.dataset.pathto.filtered_json}',

--- a/elpis/wrappers/objects/model.py
+++ b/elpis/wrappers/objects/model.py
@@ -65,7 +65,7 @@ class Model(FSObject):  # TODO not thread safe
         output_path = self.path.joinpath('output')
         output_path.mkdir(parents=True, exist_ok=True)
         # gui only handles one corpus file of extra words for language model training
-        # because it is matching explicilty on a filename (corpus.txt)
+        # because it is matching file uploads explicilty on a filename (corpus.txt)
         # but create_kaldi_structure can read content from multiple files in the model/XX/text_corpus dir
         original_text_corpus_path = self.dataset.path.joinpath('original', 'corpus.txt')
         text_corpus_path = self.path.joinpath('text_corpus')


### PR DESCRIPTION
Corpus.txt can include text to be used in training the language model. It was being saved in the dataset but not copied from the dataset to the model state dir.