### PR TITLE
compile corpora in dataset, explode/collapse punc handling

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,7 +31,7 @@ process-infer-files:
     - python3.6 /kaldi-helpers/kaldi_helpers/input/json_to_kaldi.py
                 --input_json /tmp/dirty.json
                 --output_folder /tmp/json_splitted
-                --corpus_file working_dir/input/output/tmp/corpus.txt
+                --corpus_txt working_dir/input/output/tmp/corpus.txt
                 --text_corpus /kaldi-helpers/working_dir/input/config/text_corpora
 
 reset-state:

--- a/elpis/endpoints/dataset.py
+++ b/elpis/endpoints/dataset.py
@@ -47,15 +47,18 @@ def list_existing():
         "data": data
     })
 
-
+# Handle file uploads. For now, default to the "original" dir
+# dataset.add_fp() will check file names, moving corpora files to own dir
+# later we might have a separate GUI widget for corpora files
+# which could have a different route with a different destination
 @bp.route("/files", methods=['POST'])
 def files():
     dataset: Dataset = app.config['CURRENT_DATASET']
     if dataset is None:
-        return jsonify({"status":404, "data": "No current dataset exists (perhaps create one first)"})
+        return jsonify({"status": 404, "data": "No current dataset exists (perhaps create one first)"})
     if request.method == 'POST':
         for file in request.files.getlist("file"):
-            dataset.add_fp(file, file.filename)
+            dataset.add_fp(fp=file, fname=file.filename, destination='original')
     data = {
         "files": dataset.files
     }
@@ -72,8 +75,10 @@ def settings():
         return jsonify({"status":404, "data": "No current dataset exists (perhaps create one first)"})
     if request.method == 'POST':
         dataset.tier = request.json['tier']
+        dataset.config['punctuation_to_explode_by'] = request.json['punctuation_to_explode_by']
     data = {
-        "tier": dataset.tier
+        "tier": dataset.tier,
+        "punctuation_to_explode_by": dataset.config['punctuation_to_explode_by']
     }
     return jsonify({
         "status": 200,

--- a/elpis/wrappers/input/clean_json.py
+++ b/elpis/wrappers/input/clean_json.py
@@ -15,8 +15,8 @@ Contributors:
               Nicholas Lambourne - (The University of Queensland, 2019)
 """
 
+import os
 import re
-import string
 import sys
 import nltk
 from argparse import ArgumentParser
@@ -39,7 +39,8 @@ def get_english_words() -> Set[str]:
 def clean_utterance(utterance: Dict[str, str],
                     remove_english: bool = False,
                     english_words: set = None,
-                    punctuation: str = None,
+                    punctuation_to_collapse_by: str = '',
+                    punctuation_to_explode_by: str = '',
                     special_cases: List[str] = None) -> (List[str], int):
     """
     Takes an utterance and cleans it based on the rules established by the provided parameters.
@@ -50,7 +51,10 @@ def clean_utterance(utterance: Dict[str, str],
     :param special_cases: a list of dirty_words to always remove from the output.
     :return: a tuple with a list of 'cleaned' dirty_words and a number representing the number of English dirty_words to remove.
     """
+    print("*** clean_utterance")
+    # TODO interface to include user specific tags
     translation_tags = {"@eng@", "<ind:", "<eng:"}
+    # TODO option to skip this—some lang caps are significant
     utterance_string = utterance.get("transcript").lower()
     dirty_words = utterance_string.split()
     clean_words = []
@@ -63,9 +67,10 @@ def clean_utterance(utterance: Dict[str, str],
         # If a word contains a digit, throw out whole utterance
         if bool(re.search(r"\d", word)) and not word.isdigit():
             return [], 0
-        if punctuation:
-            for mark in punctuation:
-                word = word.replace(mark, "")
+        # clean punctuation
+        word = deal_with_punctuation(text=word,
+                                     punctuation_to_collapse_by=punctuation_to_collapse_by,
+                                     punctuation_to_explode_by=punctuation_to_explode_by)
         if remove_english and len(word) > 3 and word in english_words:
             english_word_count += 1
             continue
@@ -107,7 +112,9 @@ def is_valid_utterance(clean_words: List[str],
 
 def clean_json_data(json_data: List[Dict[str, str]],
                     remove_english: bool = False,
-                    use_langid: bool = False) -> List[Dict[str, str]]:
+                    use_langid: bool = False,
+                    punctuation_to_collapse_by: str = '',
+                    punctuation_to_explode_by: str = '') -> List[Dict[str, str]]:
     """
     Clean a list of utterances (Python dictionaries) based on the given parameters.
     :param json_data: list of Python dictionaries, each must have a 'transcription' key-value.
@@ -115,7 +122,6 @@ def clean_json_data(json_data: List[Dict[str, str]],
     :param use_langid: whether or not to use the langid library to identify English to remove.
     :return: cleaned list of utterances (list of dictionaries).
     """
-    punctuation_to_remove = string.punctuation + "…’“–”‘°"
     special_cases = ["<silence>"]  # Any words you want to ignore
     langid_identifier = None
 
@@ -132,7 +138,8 @@ def clean_json_data(json_data: List[Dict[str, str]],
         clean_words, english_word_count = clean_utterance(utterance=utterance,
                                                           remove_english=remove_english,
                                                           english_words=english_words,
-                                                          punctuation=punctuation_to_remove,
+                                                          punctuation_to_collapse_by=punctuation_to_collapse_by,
+                                                          punctuation_to_explode_by=punctuation_to_explode_by,
                                                           special_cases=special_cases)
 
         if is_valid_utterance(clean_words,
@@ -147,10 +154,60 @@ def clean_json_data(json_data: List[Dict[str, str]],
     return cleaned_data
 
 
+def extract_additional_corpora(additional_corpus: str = '',
+                               corpus_txt: str = '',
+                               punctuation_to_collapse_by: str = '',
+                               punctuation_to_explode_by: str = '') -> None:
+    """
+    Takes a text file, extracts all sentences and writes them to the main corpus file.
+    :param additional_corpus: the path to a plaintext file to extract additional sentences/lines from
+    :param corpus_txt: the path to the compiled corpus.txt file
+    :param punctuation_to_collapse_by: punctuation marks to strip
+    :param punctuation_to_explode_by: punctuation marks to replace with spaces
+    """
+    print("corpus_txt", corpus_txt)
+    if os.path.exists(corpus_txt):
+        write_mode = 'a'  # append if already exists
+    else:
+        write_mode = 'w'  # make a new file if not
+    with open(corpus_txt, write_mode) as corpus_txt_file:
+        if os.path.exists(additional_corpus):
+            print(f"Extracting corpus examples from: {additional_corpus}")
+            with open(additional_corpus, "r", encoding="utf-8", ) as file_:
+                for line in file_.readlines():
+                    # clean the text along the way
+                    line = deal_with_punctuation(text=line,
+                                                 punctuation_to_collapse_by=punctuation_to_collapse_by,
+                                                 punctuation_to_explode_by=punctuation_to_explode_by)
+                    corpus_txt_file.writelines(line)
+        else:
+            print(
+                f"Provided additional text additional_corpus file path invalid: {additional_corpus}")
+
+
+def deal_with_punctuation(text: str = '',
+                          punctuation_to_collapse_by: str = '',
+                          punctuation_to_explode_by: str = '') -> str:
+    """
+    Removes punctuation from a string
+    :param text: original text
+    :param punctuation_to_collapse_by: punctuation marks to strip
+    :param punctuation_to_explode_by: punctuation marks to replace with spaces
+    :return: cleaned text
+    """
+    pattern_to_collapse_by = re.escape(punctuation_to_collapse_by)
+    pattern_to_explode_by = re.escape(punctuation_to_explode_by)
+    # Prioritise exploding first, this is set of punct marks that the user adds
+    new_text: str = re.sub(rf"[{pattern_to_explode_by}]", " ", text)
+    # then strip the rest
+    new_text = re.sub(rf"[{pattern_to_collapse_by}]", "", new_text)
+    print(f"{text} {new_text}")
+    return new_text
+
+
 def main() -> None:
     """
     Run the entire clean_json process as a command line utility.
-
     Usage: python3 clean_json.py [--i INFILE] [--o OUTFILE] [-r] [-u]
     """
     parser: ArgumentParser = ArgumentParser()
@@ -162,12 +219,18 @@ def main() -> None:
                         type=str,
                         help="The path to the clean json file to write to",
                         required=True)
-    parser.add_argument("-r", "--remove_eng",
-                        help="Remove english like utterances",
+    parser.add_argument("-r", "--remove_english",
+                        help="Remove english-like utterances",
                         action="store_true")
-    parser.add_argument("-u", "--use_lang_id",
+    parser.add_argument("-u", "--use_langid",
                         help="Use langid library to detect English",
                         action="store_true")
+    parser.add_argument("-c", "--punctuation_to_collapse_by",
+                        type=str,
+                        help="Chars to strip")
+    parser.add_argument("-e", "--punctuation_to_explode_by",
+                        type=str,
+                        help="Chars to strip and replace with spaces")
 
     arguments = parser.parse_args()
     dirty_json_data: List[Dict[str, str]] = load_json_file(arguments.infile)
@@ -176,8 +239,10 @@ def main() -> None:
     print(f"Filtering dirty json data {arguments.infile}...")
 
     filtered_data = clean_json_data(json_data=dirty_json_data,
-                                    remove_english=arguments.remove_eng,
-                                    use_langid=arguments.use_lang_id)
+                                    remove_english=arguments.remove_english,
+                                    use_langid=arguments.use_langid,
+                                    punctuation_to_collapse_by=arguments.punctuation_to_collapse_by,
+                                    punctuation_to_explode_by=arguments.punctuation_to_explode_by)
 
     write_data_to_json_file(data=list(filtered_data),
                             output=outfile)

--- a/elpis/wrappers/input/make_wordlist.py
+++ b/elpis/wrappers/input/make_wordlist.py
@@ -67,7 +67,7 @@ def extract_additional_words(file_name: str) -> List[str]:
 def generate_word_list(transcription_file: str,
                        output_file: str,
                        additional_word_list_file: str,
-                       additional_corpus_file: str
+                       additional_corpus_txt: str
                        ) -> None:
     """
     Generates the wordlist.txt file used to populate the Kaldi file structure and generate
@@ -75,7 +75,7 @@ def generate_word_list(transcription_file: str,
     :param transcription_file: path to the json file containing the transcriptions
     :param output_file: the path of the file to write the word list to
     :param additional_word_list_file: file path to additional wordlist text
-    :param additional_corpus_file: file path to the additional corpus text
+    :param additional_corpus_txt: file path to the additional corpus text
     :return:
     """
     json_data: List[Dict[str, str]] = load_json_file(transcription_file)
@@ -90,9 +90,9 @@ def generate_word_list(transcription_file: str,
         additional_words = extract_additional_words(additional_word_list_file)
         word_list.extend(additional_words)
 
-    if additional_corpus_file:
-        corpus_file_words = extract_additional_words(additional_corpus_file)
-        word_list.extend(corpus_file_words)
+    if additional_corpus_txt:
+        corpus_txt_words = extract_additional_words(additional_corpus_txt)
+        word_list.extend(corpus_txt_words)
 
     # Remove duplicates
     word_list = list(set(word_list))
@@ -122,7 +122,7 @@ def main():
                         type=str,
                         required=False,
                         help="File path to an optional additional word list.")
-    parser.add_argument("-c", "--additional_corpus_file",
+    parser.add_argument("-c", "--additional_corpus_txt",
                         type=str,
                         help="File path to the corpus.txt .",
                         required=True)
@@ -131,7 +131,7 @@ def main():
     generate_word_list(transcription_file=arguments.infile,
                        output_file=arguments.outfile,
                        additional_word_list_file=arguments.additional_word_list_file,
-                       additional_corpus_file=arguments.additional_corpus_file
+                       additional_corpus_txt=arguments.additional_corpus_txt
                        )
 
     print("Done.", file=sys.stderr)

--- a/elpis/wrappers/objects/model.py
+++ b/elpis/wrappers/objects/model.py
@@ -64,22 +64,15 @@ class Model(FSObject):  # TODO not thread safe
         # task json-to-kaldi
         output_path = self.path.joinpath('output')
         output_path.mkdir(parents=True, exist_ok=True)
-        # gui only handles one corpus file of extra words for language model training
-        # because it is matching file uploads explicilty on a filename (corpus.txt)
-        # but create_kaldi_structure can read content from multiple files in the model/XX/text_corpus dir
-        original_text_corpus_path = self.dataset.path.joinpath('original', 'corpus.txt')
-        text_corpus_path = self.path.joinpath('text_corpus')
-        text_corpus_path.mkdir(parents=True, exist_ok=True)
-        if os.path.exists(original_text_corpus_path):
-            shutil.copy(f"{original_text_corpus_path}", f"{text_corpus_path}")
-        # content from uploaded corpus file(s) will be written to file at corpus_file_path
-        corpus_file_path = self.path.joinpath('corpus.txt')
-        create_kaldi_structure(
-            input_json=f'{self.dataset.pathto.filtered_json}',
+        # Copy cleaned corpus from dataset to the model
+        dataset_corpus_txt = self.dataset.path.joinpath('cleaned', 'corpus.txt')
+        model_corpus_txt = self.path.joinpath('corpus.txt')
+        if os.path.exists(dataset_corpus_txt):
+            shutil.copy(f"{dataset_corpus_txt}", f"{model_corpus_txt}")
+        create_kaldi_structure(input_json=f'{self.dataset.pathto.filtered_json}',
             output_folder=f'{output_path}',
             silence_markers=None,
-            text_corpus=f'{text_corpus_path}',
-            corpus_file=f'{corpus_file_path}'
+            corpus_txt=f'{model_corpus_txt}'
         )
 
     def train(self, on_complete:Callable=None):


### PR DESCRIPTION
## corpus enhancements

Previously, only a single file named `corpus.txt` would be used as additional corpus data for training. The limitation was in that only this explicitly named file was copied from the uploaded file dir `original/corpus.txt` into `model/ID/text-corpora/` in the `model.py` `build_kaldi_structure` step (this was added in PR#80) . Although there was code in `json_to_kaldi.py` to compile multiple files from this `text-corpora` dir into a single one, it was redundant because only one file would be copied into the `text-corpora` dir.

My response to this has been to move the corpus compilation processing from the model `build_kaldi_structure()` preparation step back to the dataset `process()` step. I like the thought of doing file processing in the dataset step rather than thinking of it as part of the model processing.

The flow now goes: 
- Files are uploaded via dataset `add_fp()`.
- If files have the word "corpus" in their name, they are written to `dataset/ID/text_corpora/` dir. 
- All other files uploaded are written to `dataset/ID/original/`  dir. 
- Dataset `process()` now iterates the `text_corpora` dir and compiles text files into `dataset/ID/cleaned/corpus.txt` file.

One day, it would be good to add a GUI element specifically to accept corpus files, which would post files to a new endpoint, allowing the current `dataset/files` endpoint to be dedicated to transcription files. This would enable removing of the limitation of including the word "corpus" in the filenames because we could use a `destination` arg to direct the movement of files to either the `text_corpora` or `original` dirs. In preparation for this I've added the destination arg to the files endpoint with default value "original".


## punctuation

Moving the corpus cleaning from model to dataset also allowed the punctuation cleaning to happen solely in the dataset prep stage rather than being in both dataset and model.

Punctuation cleaning is done in two stages. First, one list of punctuation marks are replaced by spaces. Secondly, another list of marks are stripped. 

The two lists (`punctuation_to_explode_by` and `punctuation_to_collapse_by` respectively) are specified as config values in dataset `init()`. There is a new GUI element to update the `explode` list, by setting the current `dataset.config['punctuation_to_explode_by']` object via the `dataset/settings` endpoint.

The cleaning is handled by a new function `deal_with_punctuation()` in `clean_json.py`. Probably should rename that file now cause it is actually cleaning more than json. 🤷‍♂️

The `dataset.process()` step cleans each utterance in the transcription json data, via `clean_json_data()` which in turn calls the new `deal_with_punctuation()` function.

`dataset.process()` also cleans the corpus.txt files, when it compiles the additional corpus files in `extract_additional_corpora()`. Punctuation cleaning happens for each line as the additinoal corpus files are read, so we no longer need the `clean_corpus_txt()` function, which previously was used to clean the `corpus.txt` file.




