### PR TITLE
Tiers

### DIFF
--- a/elpis/endpoints/dataset.py
+++ b/elpis/endpoints/dataset.py
@@ -47,10 +47,11 @@ def list_existing():
         "data": data
     })
 
-# Handle file uploads. For now, default to the "original" dir
-# dataset.add_fp() will check file names, moving corpora files to own dir
+# Handle file uploads. For now, default to the "original" dir.
+# Dataset.add_fp() will check file names, moving corpora files to own dir
 # later we might have a separate GUI widget for corpora files
-# which could have a different route with a different destination
+# which could have a different route with a different destination.
+# add_fp scans the uploaded files and returns lists of all tier types and tier names for eafs
 @bp.route("/files", methods=['POST'])
 def files():
     dataset: Dataset = app.config['CURRENT_DATASET']
@@ -60,8 +61,13 @@ def files():
     if request.method == 'POST':
         for file in request.files.getlist("file"):
             dataset.add_fp(fp=file, fname=file.filename, destination='original')
+        dataset.get_elan_tier_attributes(dataset.pathto.original)
+        print(dataset.tier_types, dataset.tier_names)
+
     data = {
-        "files": dataset.files
+        "files": dataset.files,
+        "tier_types": dataset.tier_types,
+        "tier_names": dataset.tier_names
     }
     return jsonify({
         "status": 200,
@@ -75,10 +81,13 @@ def settings():
     if dataset is None:
         return jsonify({"status":404, "data": "No current dataset exists (perhaps create one first)"})
     if request.method == 'POST':
-        dataset.tier = request.json['tier']
+        dataset.tier_type = request.json['tier_type']
+        dataset.tier_name = request.json['tier_name']
         dataset.config['punctuation_to_explode_by'] = request.json['punctuation_to_explode_by']
+    print(f"saving settings {dataset.tier_type} {dataset.tier_name}")
     data = {
-        "tier": dataset.tier,
+        "tier_type": dataset.tier_type,
+        "tier_name": dataset.tier_name,
         "punctuation_to_explode_by": dataset.config['punctuation_to_explode_by']
     }
     return jsonify({

--- a/elpis/endpoints/dataset.py
+++ b/elpis/endpoints/dataset.py
@@ -62,10 +62,9 @@ def files():
         for file in request.files.getlist("file"):
             dataset.add_fp(fp=file, fname=file.filename, destination='original')
         dataset.get_elan_tier_attributes(dataset.pathto.original)
-        print(dataset.tier_types, dataset.tier_names)
-
     data = {
         "files": dataset.files,
+        "tier_max_count": dataset.tier_max_count,
         "tier_types": dataset.tier_types,
         "tier_names": dataset.tier_names
     }
@@ -81,11 +80,12 @@ def settings():
     if dataset is None:
         return jsonify({"status":404, "data": "No current dataset exists (perhaps create one first)"})
     if request.method == 'POST':
+        dataset.tier_order = int(request.json['tier_order'] or 0)
         dataset.tier_type = request.json['tier_type']
         dataset.tier_name = request.json['tier_name']
         dataset.config['punctuation_to_explode_by'] = request.json['punctuation_to_explode_by']
-    print(f"saving settings {dataset.tier_type} {dataset.tier_name}")
     data = {
+        "tier_order": dataset.tier_order,
         "tier_type": dataset.tier_type,
         "tier_name": dataset.tier_name,
         "punctuation_to_explode_by": dataset.config['punctuation_to_explode_by']

--- a/elpis/wrappers/input/elan_to_json.py
+++ b/elpis/wrappers/input/elan_to_json.py
@@ -2,7 +2,7 @@
 
 """
 Get all files in the repository can use recursive atm as long as we don't need numpy
-pass in corpus path throw an error if matching file wav isn"t found in the corpus directory
+pass in corpus path throw an error if matching file wav isn't found in the corpus directory
 
 Usage: python3 elan_to_json.py [-h] [-i INPUT_DIR] [-o OUTPUT_DIR] [-t TIER] [-j OUTPUT_JSON]
 
@@ -16,29 +16,41 @@ import sys
 import os
 import argparse
 from pympi.Elan import Eaf
-from typing import List
-from ..utilities import write_data_to_json_file
+from typing import List, Dict, Tuple, Union
+from ..utilities import load_json_file, write_data_to_json_file
 
 
-def process_eaf(input_elan_file: str, tier_name: str) -> List[dict]:
+def log_tier_info(input_eaf: Eaf = None, file_name: str = '', tier_types: List = [], corpus_tiers_file: str = 'corpus_tiers.json'):
+    tiers = []
+    for tier_type in tier_types:
+        tier_names = input_eaf.get_tier_ids_for_linguistic_type(tier_type)
+        tiers.append( { tier_type: tier_names } )
+    file_data = {"file": file_name, "tiers": tiers}
+    corpus_tiers = load_json_file(corpus_tiers_file)
+    corpus_tiers.append(file_data)
+    write_data_to_json_file(data=corpus_tiers,
+                            output=corpus_tiers_file)
+
+
+def process_eaf(input_elan_file: str = '', tier_type: str = '', tier_name: str = '', corpus_tiers_file: str = '') -> List[dict]:
     """
-    Method to process a particular tier in an eaf file (ELAN Annotation Format). It stores the transcriptions in the 
-    following format:
+    Method to process a particular tier in an eaf file (ELAN Annotation Format).
+    It stores the transcriptions in the following format:
                     {'speaker_id': <speaker_id>,
                     'audio_file_name': <file_name>,
                     'transcript': <transcription_label>,
                     'start_ms': <start_time_in_milliseconds>,
                     'stop_ms': <stop_time_in_milliseconds>}
-                    
+
     :param input_elan_file: name of input elan file
     :param tier_name: name of the elan tier to process. these tiers are nodes from the tree structure in the .eaf file.
     :return: a list of dictionaries, where each dictionary is an annotation
     """
+    print(f"process_eaf {input_elan_file} using {tier_type} {tier_name}")
+
     # Get paths to files
     input_directory, full_file_name = os.path.split(input_elan_file)
     file_name, extension = os.path.splitext(full_file_name)
-
-    input_eaf = Eaf(input_elan_file)
 
     # Look for wav file matching the eaf file in same directory
     if os.path.isfile(os.path.join(input_directory, file_name + ".wav")):
@@ -47,22 +59,50 @@ def process_eaf(input_elan_file: str, tier_name: str) -> List[dict]:
         raise ValueError(f"WAV file not found for {full_file_name}. "
                          f"Please put it next to the eaf file in {input_directory}.")
 
-    # Get annotations and parameters (things like speaker id) on the target tier
-    annotations = sorted(input_eaf.get_annotation_data_for_tier(tier_name))
-    parameters = input_eaf.get_parameters_for_tier(tier_name)
-    speaker_id = parameters.get("PARTICIPANT", "")
+    # Get tier data from Elan file
+    input_eaf = Eaf(input_elan_file)
+    tier_types: List[str] = list(input_eaf.get_linguistic_type_names())
+    tier_names: List[str] = list(input_eaf.get_tier_names())
 
-    annotations_data = []
+    # Keep this data handy for future corpus analysis
+    log_tier_info(input_eaf=input_eaf,
+                  tier_types=tier_types,
+                  file_name=file_name,
+                  corpus_tiers_file=corpus_tiers_file)
+
+    # Get annotations and parameters (things like speaker id) on the target tier
+    annotations: List[Tuple[str, str, str]] = []
+    annotations_data: List[dict] = []
+
+    if tier_type in tier_types:
+        print(f"found tier type {tier_type}")
+        tier_names = input_eaf.get_tier_ids_for_linguistic_type(tier_type)
+        tier_name = tier_names[0]
+        if tier_name:
+            print(f"found tier name {tier_name}")
+    else:
+        print("tier type not found in this file")
+
+    if tier_name in tier_names:
+        print(f"using tier name {tier_name}")
+        annotations = input_eaf.get_annotation_data_for_tier(tier_name)
+
+    if annotations:
+        print(f"annotations {annotations}")
+        annotations = sorted(annotations)
+        parameters: Dict[str,str] = input_eaf.get_parameters_for_tier(tier_name)
+        print(f"parameters {parameters}")
+        speaker_id: str = parameters.get("PARTICIPANT", "")
 
     for annotation in annotations:
-        start = annotation[0]
-        end = annotation[1]
-        annotation = annotation[2]
+        start: str = annotation[0]
+        end: str = annotation[1]
+        annotation_text: str = annotation[2]
 
-        # print("processing annotation: " + annotation, start, end)
+        print(f"annotation {annotation} {start} {end}")
         obj = {
             "audio_file_name": f"{file_name}.wav",
-            "transcript": annotation,
+            "transcript": annotation_text,
             "start_ms": start,
             "stop_ms": end
         }
@@ -75,10 +115,10 @@ def process_eaf(input_elan_file: str, tier_name: str) -> List[dict]:
 
 def main():
 
-    """ 
-    Run the entire elan_to_json.py as a command line utility. It extracts information on speaker, audio file, 
-    transcription etc. from the given tier of the specified .eaf file. 
-    
+    """
+    Run the entire elan_to_json.py as a command line utility. It extracts information on speaker, audio file,
+    transcription etc. from the given tier of the specified .eaf file.
+
     Usage: python3 elan_to_json.py [-h] [-i INPUT_DIR] [-o OUTPUT_DIR] [-t TIER] [-j OUTPUT_JSON]
     """
 
@@ -104,14 +144,16 @@ def main():
         os.makedirs(arguments.output_dir)
 
     all_files_in_directory = set(glob.glob(os.path.join(arguments.input_dir, "**"), recursive=True))
-    input_eafs_files = [ file_ for file_ in all_files_in_directory if file_.endswith(".eaf") ]
+    input_elan_files = [ file_ for file_ in all_files_in_directory if file_.endswith(".eaf") ]
 
     annotations_data = []
 
-    for input_eaf_file in input_eafs_files:
-        annotations_data.extend(process_eaf(input_eaf_file, arguments.tier))
+    for input_elan_file in input_elan_files:
+        annotations_data.extend(process_eaf(input_elan_file=input_elan_file,
+                                            tier_name=arguments.tier))
 
-    write_data_to_json_file(annotations_data, arguments.output_json)
+    write_data_to_json_file(data=annotations_data,
+                            output=arguments.output_json)
 
 
 if __name__ == "__main__":

--- a/elpis/wrappers/input/elan_to_json.py
+++ b/elpis/wrappers/input/elan_to_json.py
@@ -20,7 +20,7 @@ from typing import List, Dict, Tuple, Union
 from ..utilities import load_json_file, write_data_to_json_file
 
 
-def log_tier_info(input_eaf: Eaf = None,
+def save_tier_info(input_eaf: Eaf = None,
                   file_name: str = '',
                   tier_types: List = [],
                   corpus_tiers_file: str = 'corpus_tiers.json'):
@@ -83,7 +83,7 @@ def process_eaf(input_elan_file: str = '',
     tier_names: List[str] = list(input_eaf.get_tier_names())
 
     # Keep this data handy for future corpus analysis
-    log_tier_info(input_eaf=input_eaf,
+    save_tier_info(input_eaf=input_eaf,
                   tier_types=tier_types,
                   file_name=file_name,
                   corpus_tiers_file=corpus_tiers_file)

--- a/elpis/wrappers/input/textgrid_to_json.py
+++ b/elpis/wrappers/input/textgrid_to_json.py
@@ -17,14 +17,14 @@ from ..utilities import *
 
 def process_textgrid(input_directory: str) -> List[Dict[str, Union[str, int]]]:
     """
-    Traverses through the textgrid files in the given directory and extracts 
+    Traverses through the textgrid files in the given directory and extracts
     transcription information in each tier and creates a list of dictionaries,
-    each containing data in the following format: 
+    each containing data in the following format:
                         {'audio_file_name': <file_name>,
                         'transcript': <transcription_label>,
                         'start_ms': <start_time_in_milliseconds>,
                         'stop_ms': <stop_time_in_milliseconds>}
-                        
+
     :param input_directory: directory path containing input files from where the method
     :return: list of interval data in dictionary form
     """
@@ -50,7 +50,7 @@ def process_textgrid(input_directory: str) -> List[Dict[str, Union[str, int]]]:
 def seconds_to_milliseconds(seconds: float) -> int:
     """
     Converts from seconds to milliseconds.
-    
+
     :param seconds: time in seconds
     :return: converted time rounded to nearest millisecond
     """
@@ -59,9 +59,9 @@ def seconds_to_milliseconds(seconds: float) -> int:
 
 def main() -> None:
 
-    """ 
+    """
     Run the entire textgrid_to_json.py as a command line utility.
-    
+
     Usage: python3 textgrid_to_json.py [-h] [-i INPUT_DIR] [-o OUTPUT_DIR]
     """
 
@@ -83,7 +83,8 @@ def main() -> None:
         outfile_name = os.path.join(name + ".json")
 
     output_json = os.path.join(result_base_name, outfile_name)
-    write_data_to_json_file(intervals, output_json)
+    write_data_to_json_file(data=intervals,
+                            output=output_json)
 
 
 if __name__ == "__main__":

--- a/elpis/wrappers/input/trs_to_json.py
+++ b/elpis/wrappers/input/trs_to_json.py
@@ -145,7 +145,8 @@ def main() -> None:
     for file_name in transcript_names:
         utterances = utterances + process_trs(file_name, arguments.verbose)
 
-    write_data_to_json_file(utterances, arguments.output_json)
+    write_data_to_json_file(data=utterances,
+                            output=arguments.output_json)
 
 
 if __name__ == '__main__':

--- a/elpis/wrappers/objects/dataset.py
+++ b/elpis/wrappers/objects/dataset.py
@@ -256,8 +256,7 @@ class Dataset(FSObject):
                                   tier_order=self.tier_order,
                                   tier_type=self.tier_type,
                                   tier_name=self.tier_name,
-                                  corpus_tiers_file=f'{self.pathto.corpus_tiers}'
-                                  )
+                                  corpus_tiers_file=f'{self.pathto.corpus_tiers}')
                 dirty.extend(obj)
         # TODO other options for command below: remove_english=arguments.remove_eng, use_langid=arguments.use_lang_id
         # Clean punctuation

--- a/elpis/wrappers/utilities/json_utilities.py
+++ b/elpis/wrappers/utilities/json_utilities.py
@@ -22,12 +22,11 @@ def load_json_file(file_name: str) -> List[Dict[str, str]]:
     :return a Python dictionary with the contents of the JSON file.
     """
     data = []
-    with open(file_name, "r", encoding="utf-8") as file_:
-        try:
+    if os.path.exists(file_name) and os.path.getsize(file_name) > 0:
+        with open(file_name, "r", encoding="utf-8") as file_:
             data = json.load(file_)
-        except JSONDecodeError:
-            pass
     return data
+
 
 def write_data_to_json_file(data: object = {}, output: Union[str, TextIOWrapper] = []) -> None:
     """

--- a/elpis/wrappers/utilities/json_utilities.py
+++ b/elpis/wrappers/utilities/json_utilities.py
@@ -4,26 +4,32 @@ Collection of utilities for working with JSON files.
 Copyright: University of Queensland, 2019
 Contributors:
              Nicholas Lambourne - (University of Queensland, 2018)
+             Ben Foley - (University of Queensland, 2020)
 """
 
 import json
-from typing import Union
+from json.decoder import JSONDecodeError
+import os
+from typing import List, Dict, Union
 from _io import TextIOWrapper
 
 
-def load_json_file(file_name: str) -> object:
+def load_json_file(file_name: str) -> List[Dict[str, str]]:
     """
     Given a filename (parameter) containing JSON, load and
     return the a list of python dictionaries with containing the same information.
     :param file_name: name of file containing JSON to read from.
     :return a Python dictionary with the contents of the JSON file.
     """
-    file = open(file_name, "r", encoding="utf-8")
-    data: object = json.load(file)
+    data = []
+    with open(file_name, "r", encoding="utf-8") as file_:
+        try:
+            data = json.load(file_)
+        except JSONDecodeError:
+            pass
     return data
 
-
-def write_data_to_json_file(data: object, output: Union[str, TextIOWrapper]) -> None:
+def write_data_to_json_file(data: object = {}, output: Union[str, TextIOWrapper] = []) -> None:
     """
     Writes the given Python dictionary (or list) object to a JSON file at the the given
     output location (which can either be a file - specified as a string, or


### PR DESCRIPTION
This adds options to select transcriptions by Elan tier order, type or name, rather than the previous limitation to only select by name. 

When files are uploaded, they are read to determine what all the tier types, tier names and number of tiers are across all the files. This info is passed back to the GUI, which offers a form with selects to choose either a tier order, type or name. Only one of these can be selected (changing a select to choose one or the other will reset the other two). See screenshot of the interface attached. When the setting is saved, this updates the dataset object, storing the tier_order, tier_type, tier_name values for later. 

During `dataset.process()` the files are read, and `elan_to_json.py process_eaf()` will look for a tier based on the `dataset.config` setting of order, type or name. 

If order is specified, it gets the list of tiers in each file and uses that order num as the index from the names list to get the target tier name. Note that this can give weird results if, say there's a file in there that has a gloss tier uppermost, and another file has translation tier uppermost. 

If tier type is specified, the list of tier types is retrieved from a file and then the first tier name that has that type is used as the target tier name. Elan files can have multiple tiers with the same type, future work might support reading data from multiple tiers in each file. 

Finally, if a tier name has been specified, process_eaf() will use that.

With tier_name known, the annotations are retrieved as before.

Data for testing can be downloaded here:
https://github.com/CoEDL/dev-corpora

GUI changes are in `tiers` branch:
https://github.com/CoEDL/elpis-gui/tree/tiers
