### PR TITLE
Not deleting utterances that have words with digits in them.

### DIFF
--- a/elpis/wrappers/input/clean_json.py
+++ b/elpis/wrappers/input/clean_json.py
@@ -67,10 +67,6 @@ def clean_utterance(utterance: Dict[str, str],
             continue
         if word in translation_tags:  # Translations / ignore
             return [], 0
-        # If a word contains a digit, throw out whole utterance
-        if bool(re.search(r"\d", word)) and not word.isdigit():
-            return [], 0
-        # clean punctuation
         word = deal_with_punctuation(text=word,
                                      punctuation_to_collapse_by=punctuation_to_collapse_by,
                                      punctuation_to_explode_by=punctuation_to_explode_by)


### PR DESCRIPTION
`clean_utterance()` in `clean_json.py` removes any utterance that contains a token with a digit in it. This behaviour will break training for languages where digits are used as part of the orthography. For instance, the romanization of Chatino uses digits to indicate tone. As a result all utterances from the corpus are removed.

Why was the behaviour there in the first place? Perhaps the idea is that some transcriptions will contain digits for which the pronunciation in the language will be unknown? If that's the case I think the check should be done somewhere else such as where the G2P rules or the pronunciation lexicon are used, since it's possible that there would be pronunciations supplied for digits.

This PR is a work in progress I suppose, because if there was a reason that check for digits was done in the first place then this merge would break something else.