### PR TITLE
Fix container build by updating npm to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,8 @@ RUN wget https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
 # Add node, npm and xml-js
 RUN apt-get install -y nodejs build-essential npm && \
     #ln -s /usr/bin/nodejs /usr/bin/node && \
+    npm install -g npm \
+    hash -d npm \
     npm install -g xml-js
 
 # Add moustache templates as mo


### PR DESCRIPTION
We should probably pin dependencies in the docker file instead, this stop-gap just updates npm to latest. After updating it clears npm from the bash cache to force lookup to the latest version.