### PR TITLE
match state path to new loc /state

### DIFF
--- a/elpis/test/test_transcription.py
+++ b/elpis/test/test_transcription.py
@@ -13,7 +13,7 @@ from . import test_pipeline
 def mock_model(tmpdir_factory):
     base_path = tmpdir_factory.mktemp("pipeline")
     base_path = Path(base_path)
-    if not base_path.joinpath('state').exists():
+    if not base_path.joinpath('/state').exists():
         kaldi = KaldiInterface(f'{base_path}/state')
 
         ds = kaldi.new_dataset('dataset_x')

--- a/examples/cli/elan/transcribe.py
+++ b/examples/cli/elan/transcribe.py
@@ -4,7 +4,7 @@ from elpis.engines.common.objects.interface import Interface
 # ======
 # Create a Kaldi interface directory (where all the associated files/objects
 # will be stored).
-elpis = Interface(path='state', use_existing=True)
+elpis = Interface(path='/state', use_existing=True)
 
 # Step 1
 # ======


### PR DESCRIPTION
Sometime recently the default interface state location was moved from /elpis/state to /state. 
```
# /elpis/__init__.py
interface_path = Path(os.path.join(elpis_path, '/state'))
```

But the transcription test file and the transcription cli demo file missed the update. Poor things.