### PR TITLE
Bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="docs/img/elpis.png" width="250px"/></p>
 
-# Elpis (Accelerated Transcription for Linguists)
+# Elpis (Accelerated Transcription)
 
 [![Build Status](https://travis-ci.org/CoEDL/elpis.svg?branch=master)](https://travis-ci.org/CoEDL/elpis)
 [![Coverage Status](https://coveralls.io/repos/github/CoEDL/elpis/badge.svg?branch=master)](https://coveralls.io/github/CoEDL/elpis?branch=master)

--- a/elpis/__init__.py
+++ b/elpis/__init__.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 def create_app(test_config=None):
     # Called by the flask run command in the cli.
-    print("ben create_app")
     GUI_PUBLIC_DIR = "/elpis-gui/build"
 
     # Setup static resources

--- a/elpis/__init__.py
+++ b/elpis/__init__.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 def create_app(test_config=None):
     # Called by the flask run command in the cli.
-
+    print("ben create_app")
     GUI_PUBLIC_DIR = "/elpis-gui/build"
 
     # Setup static resources
@@ -49,16 +49,19 @@ def create_app(test_config=None):
     # stores all the artifacts that user has generated.
     interface_path = Path(os.path.join(elpis_path, '/state'))
     if not interface_path.exists():
+        print("no interface exists")
         app.config['INTERFACE'] = Interface(interface_path)
     else:
-        app.config['INTERFACE'] = Interface.load(interface_path)
-    app.config['CURRENT_DATASET'] = None # not okay for multi-user
-    app.config['CURRENT_PRON_DICT'] = None # not okay for multi-user & need to remove later because it is Kaldi-specific.
-    app.config['CURRENT_MODEL'] = None # not okay for multi-user
+        print("interface exists, load it")
+        app.config['INTERFACE'] = Interface(interface_path, use_existing=True)
+    # app.config['CURRENT_DATASET'] = None # not okay for multi-user
+    # app.config['CURRENT_PRON_DICT'] = None # not okay for multi-user & need to remove later because it is Kaldi-specific.
+    # app.config['CURRENT_MODEL'] = None # not okay for multi-user
+    # app.config['CURRENT_TRANSCRIPTION'] = None  # not okay for multi-user
 
     # add the endpoints routes
     app.register_blueprint(endpoints.bp)
-    print(app.url_map)
+    # print(app.url_map)
 
     # the rest of the routes below are for the single file react app.
     @app.route('/index.html')

--- a/elpis/endpoints/config.py
+++ b/elpis/endpoints/config.py
@@ -2,6 +2,8 @@ from ..blueprint import Blueprint
 from flask import current_app as app, jsonify, request
 from elpis.engines import Interface, ENGINES
 import shutil
+import os
+import glob
 
 bp = Blueprint("config", __name__, url_prefix="/config")
 
@@ -9,11 +11,7 @@ bp = Blueprint("config", __name__, url_prefix="/config")
 @bp.route("/reset", methods=['GET', 'POST'])
 def reset():
     current_interface_path = app.config['INTERFACE'].path
-    shutil.rmtree(current_interface_path)
     app.config['INTERFACE'] = Interface(current_interface_path)
-    app.config['CURRENT_DATASET'] = None  # not okay for multi-user
-    app.config['CURRENT_PRON_DICT'] = None  # not okay for multi-user
-    app.config['CURRENT_MODEL'] = None  # not okay for multi-user
     data = {
         "message": "reset ok"
     }

--- a/elpis/engines/common/objects/interface.py
+++ b/elpis/engines/common/objects/interface.py
@@ -47,7 +47,7 @@ class Interface(FSObject):
             pass
         config_file_path = path.joinpath(Interface._config_file)
         try:
-            if (use_existing == True
+            if (use_existing is True
                 and path.exists()
                 and path.is_dir()
                 and config_file_path.exists()
@@ -65,11 +65,11 @@ class Interface(FSObject):
                 # local filesystem into the docker container.
                 # Error is "Device or resource busy: '/state'"
                 # We need to keep the dir and delete the contents...
-                for root, dirs, files in os.walk(path):
-                    for f in files:
-                        os.unlink(os.path.join(root, f))
-                    for d in dirs:
-                        shutil.rmtree(os.path.join(root, d))
+                for root, subdirectories, files in os.walk(path):
+                    for file_ in files:
+                        os.unlink(os.path.join(root, file_))
+                    for directory in subdirectories:
+                        shutil.rmtree(os.path.join(root, directory))
 
             super().__init__(
                 parent_path=path.parent,
@@ -91,9 +91,6 @@ class Interface(FSObject):
                 parent_path=path.parent,
                 dir_name=path.name
             )
-
-
-            
         
         # ensure object directories exist
         self.datasets_path = self.path.joinpath('datasets')
@@ -120,8 +117,6 @@ class Interface(FSObject):
         KI needs a flag to know whether to set these objects or skip initialising them.
         For now, explicitly set them... sorry CLI.
         """
-
-        
 
         # make a default logger
         self.new_logger(default=True)
@@ -283,4 +278,3 @@ class Interface(FSObject):
 
     def set_engine(self, engine):
         self.engine = engine
-

--- a/elpis/engines/common/objects/interface.py
+++ b/elpis/engines/common/objects/interface.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+import shutil
 from shutil import rmtree
 
 from appdirs import user_data_dir
@@ -36,6 +37,7 @@ class Interface(FSObject):
             #     name=name
             # )
         
+        print(f"ben interface __init__")
 
         path = Path(path).absolute()
 
@@ -61,7 +63,16 @@ class Interface(FSObject):
         except InvalidInterfaceError:
             # Must wipe the interface and make a new one
             if path.exists():
-                rmtree(path)
+                # Tempted to use shutil.rmtree? It breaks if we have mounted /state from
+                # local filesystem into the docker container.
+                # Error is "Device or resource busy: '/state'"
+                # We need to keep the dir and delete the contents...
+                for root, dirs, files in os.walk(path):
+                    for f in files:
+                        os.unlink(os.path.join(root, f))
+                    for d in dirs:
+                        shutil.rmtree(os.path.join(root, d))
+
             super().__init__(
                 parent_path=path.parent,
                 dir_name=path.name,

--- a/elpis/engines/common/objects/interface.py
+++ b/elpis/engines/common/objects/interface.py
@@ -37,8 +37,6 @@ class Interface(FSObject):
             #     name=name
             # )
         
-        print(f"ben interface __init__")
-
         path = Path(path).absolute()
 
         # === Check if the existing interface is valid ===================

--- a/elpis/test/test_transcription.py
+++ b/elpis/test/test_transcription.py
@@ -13,7 +13,7 @@ from . import test_pipeline
 def mock_model(tmpdir_factory):
     base_path = tmpdir_factory.mktemp("pipeline")
     base_path = Path(base_path)
-    if not base_path.joinpath('state').exists():
+    if not base_path.joinpath('/state').exists():
         kaldi = KaldiInterface(f'{base_path}/state')
 
         ds = kaldi.new_dataset('dataset_x')

--- a/examples/cli/elan/transcribe.py
+++ b/examples/cli/elan/transcribe.py
@@ -4,7 +4,7 @@ from elpis.engines.common.objects.interface import Interface
 # ======
 # Create a Kaldi interface directory (where all the associated files/objects
 # will be stored).
-elpis = Interface(path='state', use_existing=True)
+elpis = Interface(path='/state', use_existing=True)
 
 # Step 1
 # ======


### PR DESCRIPTION
I like to mount my local state into the docker container so I can see what's going on really easily. But this breaks the reset button because it can't rmtree, (error is "Device or resource busy: '/state'").

This commit replaces rmtree with a more verbose deletion of files and folders in the /state dir but leaves /state itself alone. 
 
Also, commented out the `app.config['CURRENT_DATASET'] = None` stuff from init.py. It doesn't seem to make a difference when starting up whether it's there or not. Stage one of removing it if really not needed...