### PR TITLE
translate l2s line endings

### DIFF
--- a/elpis/endpoints/pron_dict.py
+++ b/elpis/endpoints/pron_dict.py
@@ -63,7 +63,7 @@ def l2s():
         file = request.files['file']
         pron_dict.set_l2s_fp(file)
     data = {
-        "l2s": pron_dict.get_l2s()
+        "l2s": pron_dict.get_l2s_content()
     }
     return jsonify({
         "status": 200,

--- a/elpis/engines/common/objects/pron_dict.py
+++ b/elpis/engines/common/objects/pron_dict.py
@@ -62,14 +62,15 @@ class PronDict(FSObject):
         self.config['l2s'] = True
 
     def set_l2s_content(self, content: bytes):
-        tmp = self.path.joinpath('l2s-tmp.txt')
-        with tmp.open(mode='wb') as fout:
+        tmp_l2s_path = self.path.joinpath('tmp_l2s.txt')
+        with tmp_l2s_path.open(mode='wb') as fout:
             fout.write(content)
-        with tmp.open(mode='r') as file_raw, self.l2s_path.open(mode='w', encoding='utf-8') as file_translated:
+        # translate line endings from Win to Unix for Kaldi
+        with tmp_l2s_path.open(mode='r') as file_raw, self.l2s_path.open(mode='w', encoding='utf-8') as file_translated:
             file_translated.write(file_raw.read().replace('\r\n', '\n'))
+        if os.path.exists(tmp_l2s_path):
+            os.remove(tmp_l2s_path)
         self.config['l2s'] = True
-        if os.path.exists(tmp):
-            os.remove(tmp)
 
     def get_l2s_content(self):
         try:

--- a/elpis/engines/common/objects/pron_dict.py
+++ b/elpis/engines/common/objects/pron_dict.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from io import BufferedIOBase
 
@@ -60,11 +61,15 @@ class PronDict(FSObject):
         self.set_l2s_content(file.read())
         self.config['l2s'] = True
 
-    def set_l2s_content(self, content: str):
-        # TODO: this function uses parameter str, and must be bytes or UTF-16
-        with self.l2s_path.open(mode='wb') as fout:
+    def set_l2s_content(self, content: bytes):
+        tmp = self.path.joinpath('l2s-tmp.txt')
+        with tmp.open(mode='wb') as fout:
             fout.write(content)
+        with tmp.open(mode='r') as file_raw, self.l2s_path.open(mode='w', encoding='utf-8') as file_translated:
+            file_translated.write(file_raw.read().replace('\r\n', '\n'))
         self.config['l2s'] = True
+        if os.path.exists(tmp):
+            os.remove(tmp)
 
     def get_l2s_content(self):
         try:
@@ -73,9 +78,6 @@ class PronDict(FSObject):
         except FileNotFoundError:
             return False
 
-    def get_l2s(self):
-        with self.l2s_path.open(mode='r') as fin:
-            return fin.read()
 
     def generate_lexicon(self):
         # task make-prn-dict


### PR DESCRIPTION
Using `letter-to-sound.txt` files created on Windows breaks the pron_dict, due to line endings being incompatible with what Kaldi expects. This replaces win `\r\n` with unix `\n` line endings.

Also removes `get_l2s` in favour of `get_l2s_content`.