### PR TITLE
Throw error on duplicate names

### DIFF
--- a/elpis/endpoints/dataset.py
+++ b/elpis/endpoints/dataset.py
@@ -3,7 +3,7 @@ from ..blueprint import Blueprint
 from flask import current_app as app, jsonify
 from elpis.engines import Interface
 from elpis.engines.common.objects.dataset import Dataset
-from elpis.engines.kaldi.errors import KaldiError
+from elpis.engines.common.errors import InterfaceError
 
 bp = Blueprint("dataset", __name__, url_prefix="/dataset")
 
@@ -13,7 +13,7 @@ def new():
     interface: Interface = app.config['INTERFACE']
     try:
         dataset = interface.new_dataset(request.json['name'])
-    except KaldiError as e:
+    except InterfaceError as e:
         return jsonify({
             "status": 500,
             "error": e.human_message

--- a/elpis/endpoints/dataset.py
+++ b/elpis/endpoints/dataset.py
@@ -13,20 +13,20 @@ def new():
     interface: Interface = app.config['INTERFACE']
     try:
         dataset = interface.new_dataset(request.json['name'])
-        print(f"****{request.json['name']}****")
-        app.config['CURRENT_DATASET'] = dataset
-        data = {
-            "state": dataset.config._load()
-        }
-        return jsonify({
-            "status": 200,
-            "data": data
-        })
     except KaldiError as e:
         return jsonify({
             "status": 500,
             "error": e.human_message
         })
+    print(f"****{request.json['name']}****")
+    app.config['CURRENT_DATASET'] = dataset
+    data = {
+        "state": dataset.config._load()
+    }
+    return jsonify({
+        "status": 200,
+        "data": data
+    })
 
 
 @bp.route("/load", methods=['POST'])

--- a/elpis/endpoints/model.py
+++ b/elpis/endpoints/model.py
@@ -2,7 +2,7 @@ from flask import request, current_app as app, jsonify
 from ..blueprint import Blueprint
 import subprocess
 from elpis.engines.common.objects.model import Model
-from elpis.engines.kaldi.errors import KaldiError
+from elpis.engines.common.errors import InterfaceError
 
 bp = Blueprint("model", __name__, url_prefix="/model")
 
@@ -26,7 +26,7 @@ def new():
     interface = app.config['INTERFACE']
     try:
         model = interface.new_model(request.json["name"])
-    except KaldiError as e:
+    except InterfaceError as e:
         return jsonify({
             "status": 500,
             "error": e.human_message

--- a/elpis/endpoints/pron_dict.py
+++ b/elpis/endpoints/pron_dict.py
@@ -3,6 +3,7 @@ from ..blueprint import Blueprint
 from flask import current_app as app, jsonify
 from elpis.engines import Interface
 from elpis.engines.common.objects.pron_dict import PronDict
+from elpis.engines.kaldi.errors import KaldiError
 
 
 bp = Blueprint("pron_dict", __name__, url_prefix="/pron-dict")
@@ -11,7 +12,14 @@ bp = Blueprint("pron_dict", __name__, url_prefix="/pron-dict")
 @bp.route("/new", methods=['POST'])
 def new():
     interface: Interface = app.config['INTERFACE']
-    pron_dict = interface.new_pron_dict(request.json['name'])
+    try:
+        pron_dict = interface.new_pron_dict(request.json['name'])
+    except KaldiError as e:
+        return jsonify({
+            "status": 500,
+            "error": e.human_message
+        })
+    print(f"****{request.json['name']}****")
     dataset = interface.get_dataset(request.json['dataset_name'])
     pron_dict.link(dataset)
     app.config['CURRENT_PRON_DICT'] = pron_dict

--- a/elpis/endpoints/pron_dict.py
+++ b/elpis/endpoints/pron_dict.py
@@ -3,7 +3,7 @@ from ..blueprint import Blueprint
 from flask import current_app as app, jsonify
 from elpis.engines import Interface
 from elpis.engines.common.objects.pron_dict import PronDict
-from elpis.engines.kaldi.errors import KaldiError
+from elpis.engines.common.errors import InterfaceError
 
 
 bp = Blueprint("pron_dict", __name__, url_prefix="/pron-dict")
@@ -14,7 +14,7 @@ def new():
     interface: Interface = app.config['INTERFACE']
     try:
         pron_dict = interface.new_pron_dict(request.json['name'])
-    except KaldiError as e:
+    except InterfaceError as e:
         return jsonify({
             "status": 500,
             "error": e.human_message

--- a/elpis/engines/common/errors.py
+++ b/elpis/engines/common/errors.py
@@ -1,4 +1,4 @@
-class KaldiError(Exception):
+class InterfaceError(Exception):
     def __init__(self, message, human_message=None):
         super().__init__(message)
         if human_message is None:

--- a/elpis/engines/common/objects/interface.py
+++ b/elpis/engines/common/objects/interface.py
@@ -145,7 +145,7 @@ class Interface(FSObject):
         if dsname in self.config['datasets'].keys():
             raise KaldiError(
                 f'Tried adding \'{dsname}\' which is already in {existing_names} with hash {self.config["datasets"][dsname]}.',
-                human_message=f'data set with name "{dsname}" already exists'
+                human_message=f'dataset with name "{dsname}" already exists'
             )
         ds = Dataset(parent_path=self.datasets_path, name=dsname)
         datasets = self.config['datasets']
@@ -164,6 +164,12 @@ class Interface(FSObject):
         return names
 
     def new_pron_dict(self, pdname):
+        existing_names = self.list_pron_dicts()
+        if pdname in self.config['pron_dicts'].keys():
+            raise KaldiError(
+                f'Tried adding \'{pdname}\' which is already in {existing_names} with hash {self.config["pron_dicts"][pdname]}.',
+                human_message=f'pron dict with name "{pdname}" already exists'
+            )
         pd = PronDict(parent_path=self.pron_dicts_path, name=pdname)
         pron_dicts = self.config['pron_dicts']
         pron_dicts[pdname] = pd.hash
@@ -195,6 +201,12 @@ class Interface(FSObject):
         if self.engine is None:
             raise RuntimeError("Engine must be set before model creation")
         print(self.engine)
+        existing_names = self.list_models()
+        if mname in self.config['models'].keys():
+            raise KaldiError(
+                f'Tried adding \'{mname}\' which is already in {existing_names} with hash {self.config["models"][mname]}.',
+                human_message=f'model with name "{mname}" already exists'
+            )
         m = self.engine.model(parent_path=self.models_path, name=mname)
         models = self.config['models']
         models[mname] = m.hash
@@ -238,6 +250,7 @@ class Interface(FSObject):
     def new_transcription(self, tname):
         if self.engine is None:
             raise RuntimeError("Engine need to be set prior to transcription")
+        # no name conflict because transcriptions have auto-generated names
         t = self.engine.transcription(parent_path=self.transcriptions_path, name=tname)
         transcriptions = self.config['transcriptions']
         transcriptions[tname] = t.hash

--- a/elpis/engines/common/objects/interface.py
+++ b/elpis/engines/common/objects/interface.py
@@ -2,13 +2,12 @@ import json
 import os
 from pathlib import Path
 import shutil
-from shutil import rmtree
 
 from appdirs import user_data_dir
 from elpis.engines.common.objects.fsobject import FSObject
 from elpis.engines.common.utilities import hasher
 from elpis.engines.common.utilities.logger import Logger
-from elpis.engines.kaldi.errors import KaldiError
+from elpis.engines.common.errors import InterfaceError
 from elpis.engines.common.objects.dataset import Dataset
 from elpis.engines.common.objects.pron_dict import PronDict
 
@@ -143,9 +142,9 @@ class Interface(FSObject):
     def new_dataset(self, dsname):
         existing_names = self.list_datasets()
         if dsname in self.config['datasets'].keys():
-            raise KaldiError(
+            raise InterfaceError(
                 f'Tried adding \'{dsname}\' which is already in {existing_names} with hash {self.config["datasets"][dsname]}.',
-                human_message=f'dataset with name "{dsname}" already exists'
+                human_message=f'Dataset with name "{dsname}" already exists'
             )
         ds = Dataset(parent_path=self.datasets_path, name=dsname)
         datasets = self.config['datasets']
@@ -155,7 +154,7 @@ class Interface(FSObject):
 
     def get_dataset(self, dsname):
         if dsname not in self.list_datasets():
-            raise KaldiError(f'Tried to load a dataset called "{dsname}" that does not exist')
+            raise InterfaceError(f'Tried to load a dataset called "{dsname}" that does not exist')
         hash_dir = self.config['datasets'][dsname]
         return Dataset.load(self.datasets_path.joinpath(hash_dir))
 
@@ -166,9 +165,9 @@ class Interface(FSObject):
     def new_pron_dict(self, pdname):
         existing_names = self.list_pron_dicts()
         if pdname in self.config['pron_dicts'].keys():
-            raise KaldiError(
+            raise InterfaceError(
                 f'Tried adding \'{pdname}\' which is already in {existing_names} with hash {self.config["pron_dicts"][pdname]}.',
-                human_message=f'pron dict with name "{pdname}" already exists'
+                human_message=f'Pronunciation dictionary with name "{pdname}" already exists'
             )
         pd = PronDict(parent_path=self.pron_dicts_path, name=pdname)
         pron_dicts = self.config['pron_dicts']
@@ -178,7 +177,7 @@ class Interface(FSObject):
 
     def get_pron_dict(self, pdname):
         if pdname not in self.list_pron_dicts():
-            raise KaldiError(f'Tried to load a pron dict called "{pdname}" that does not exist')
+            raise InterfaceError(f'Tried to load a pron dict called "{pdname}" that does not exist')
         hash_dir = self.config['pron_dicts'][pdname]
         pd = PronDict.load(self.pron_dicts_path.joinpath(hash_dir))
         print(dir(pd.config))
@@ -203,9 +202,9 @@ class Interface(FSObject):
         print(self.engine)
         existing_names = self.list_models()
         if mname in self.config['models'].keys():
-            raise KaldiError(
+            raise InterfaceError(
                 f'Tried adding \'{mname}\' which is already in {existing_names} with hash {self.config["models"][mname]}.',
-                human_message=f'model with name "{mname}" already exists'
+                human_message=f'Model with name "{mname}" already exists'
             )
         m = self.engine.model(parent_path=self.models_path, name=mname)
         models = self.config['models']
@@ -215,7 +214,7 @@ class Interface(FSObject):
 
     def get_model(self, mname):
         if mname not in self.list_models():
-            raise KaldiError(f'Tried to load a model called "{mname}" that does not exist')
+            raise InterfaceError(f'Tried to load a model called "{mname}" that does not exist')
         hash_dir = self.config['models'][mname]
         m = self.engine.model.load(self.models_path.joinpath(hash_dir))
         m.dataset = self.get_dataset(m.config['dataset_name'])
@@ -259,7 +258,7 @@ class Interface(FSObject):
 
     def get_transcription(self, tname):
         if tname not in self.list_transcriptions():
-            raise KaldiError(f'Tried to load a transcription called "{tname}" that does not exist')
+            raise InterfaceError(f'Tried to load a transcription called "{tname}" that does not exist')
         hash_dir = self.config['transcriptions'][tname]
         t = self.engine.transcription.load(self.transcriptions_path.joinpath(hash_dir))
         t.model = self.get_model(t.config['model_name'])


### PR DESCRIPTION
Fixes error where attempting to add a dataset, pron dict or model with name matching existing name would break. This PR passes the error message to the GUI