### PR TITLE
temporary work-around for loading dataset settings ui state

### DIFF
--- a/elpis/engines/common/objects/dataset.py
+++ b/elpis/engines/common/objects/dataset.py
@@ -67,10 +67,15 @@ class Dataset(FSObject):
         self = super().load(base_path)
         self.pathto = DSPaths(self.path)
         self.__files = [ self.pathto.original.joinpath(path) for path in self.config['files']]
+        # at this point config has the previous state
         self._importer = self.config['importer']
+        temp_state = self._importer
+        # rebuild the importer, this resets importer ui
         if self._importer is not None:
             importer_name = self._importer['name']
             self.select_importer(importer_name)
+        # importer has been reset, copy the old state back
+        self.config['importer'] = temp_state
         return self
 
     def select_importer(self, name: str):


### PR DESCRIPTION
This will need to be done properly some time, but for now this temporary workaround enables `dataset.load` to reuse the previous settings ui. Currently, dataset.load resets the config thus wiping the ui values, thus the gui settings are empty even though loading a dataset shows the files. Reusing the ui is important so that users don't feel like something has broken by the tier names etc not being available after a reload, even though files are shown. To explain that more.. if I upload Elan files and the tier selects are populated with the tier names, I would expect that reloading the dataset would show the tier names in the ui, rather than being a blank ui.

In the long term, perhaps the importer should store ui values separately from the config, so the config could be reset but the values persisted?