### PR TITLE
add newline to corpus if missing and reset to avoid multiple writes

### DIFF
--- a/elpis/engines/common/input/clean_json.py
+++ b/elpis/engines/common/input/clean_json.py
@@ -204,7 +204,7 @@ def extract_additional_corpora(additional_corpus: str = '',
                         deal_with_punctuation(text=line,
                                               punctuation_to_collapse_by=punctuation_to_collapse_by,
                                               punctuation_to_explode_by=punctuation_to_explode_by)
-                    if '\n' not in line:
+                    if not line.endswith('\n'):
                         line = line + '\n'
                     corpus_txt_file.writelines(line)
         else:

--- a/elpis/engines/common/input/clean_json.py
+++ b/elpis/engines/common/input/clean_json.py
@@ -204,6 +204,8 @@ def extract_additional_corpora(additional_corpus: str = '',
                         deal_with_punctuation(text=line,
                                               punctuation_to_collapse_by=punctuation_to_collapse_by,
                                               punctuation_to_explode_by=punctuation_to_explode_by)
+                    if '\n' not in line:
+                        line = line + '\n'
                     corpus_txt_file.writelines(line)
         else:
             print(f"Provided additional text additional_corpus file path invalid: "

--- a/elpis/engines/common/objects/dataset.py
+++ b/elpis/engines/common/objects/dataset.py
@@ -351,6 +351,9 @@ class Dataset(FSObject):
                 corpus_files.append(file_)
         print(f"corpus_files {corpus_files}")
         # Compile and clean the additional corpora content into a single file
+        # Reset first to prevent files being added multiple times
+        if os.path.exists(self.pathto.corpus_txt):
+            self.pathto.corpus_txt.unlink()
         for additional_corpus in corpus_files:
             extract_additional_corpora(additional_corpus=additional_corpus,
                                        corpus_txt=f'{self.pathto.corpus_txt}',


### PR DESCRIPTION
This fixes a bug where uploading corpus text files can result in multiple copies of the content being written to the cleaned corpus file, and lines being written onto same line as previous content.

The first scenario can arise from someone uploading a corpus.txt file, then adding it again! The same content would be written twice to the cleaned data. By resetting the cleaned file we only get one instance of the uploaded text.

The second scenario arises when corpus text file doesn't end with a trailing newline. In this case, adding a second file would write the first line of the second file to the last line of the first file's content. Although the GUI currently only supports single corpus text file upload, the backend supports multiple so this is getting ready for a front-end upgrade :-) 