### PR TITLE
select datasets without prondict for non-kaldi models

### DIFF
--- a/elpis/endpoints/config.py
+++ b/elpis/endpoints/config.py
@@ -37,7 +37,7 @@ def engine_load():
     engine_name = request.json["engine_name"]
     if engine_name not in ENGINES:
         return jsonify({"status": 404,
-                        "data": "No current dataset exists (perhaps create one first)"})
+                        "data": "Engine not found in ENGINES"})
     engine = ENGINES[engine_name]
     interface = app.config['INTERFACE']
     interface.set_engine(engine)
@@ -48,3 +48,21 @@ def engine_load():
         "status": 200,
         "data": data
     })
+
+
+@bp.route("/object-names", methods=['GET', 'POST'])
+def object_names():
+    interface: Interface = app.config['INTERFACE']
+    data = {
+        "object_names": {
+            "datasets": interface.list_datasets(),
+            "pron_dicts": interface.list_pron_dicts_verbose(),  # includes pd name and ds name
+            "models": interface.list_models()
+        }
+    }
+    print(data)
+    return jsonify({
+        "status": 200,
+        "data": data
+    })
+

--- a/elpis/endpoints/model.py
+++ b/elpis/endpoints/model.py
@@ -36,9 +36,7 @@ def new():
     model.link_dataset(dataset)
     app.config['CURRENT_DATASET'] = dataset
     if 'engine' in request.json and request.json['engine'] == 'kaldi':
-        print("here")
         pron_dict = interface.get_pron_dict(request.json['pron_dict_name'])
-        print(request.json['pron_dict_name'])
         model.link_pron_dict(pron_dict)
         app.config['CURRENT_PRON_DICT'] = pron_dict
         model.build_kaldi_structure()

--- a/elpis/endpoints/model.py
+++ b/elpis/endpoints/model.py
@@ -31,12 +31,18 @@ def new():
             "status": 500,
             "error": e.human_message
         })
-    pron_dict = interface.get_pron_dict(request.json['pron_dict_name'])
-    dataset = interface.get_dataset(pron_dict.dataset.name)
-    model.link(dataset, pron_dict)
-    model.build_kaldi_structure()
+
+    dataset = interface.get_dataset(request.json['dataset_name'])
+    model.link_dataset(dataset)
     app.config['CURRENT_DATASET'] = dataset
-    app.config['CURRENT_PRON_DICT'] = pron_dict
+    if 'engine' in request.json and request.json['engine'] == 'kaldi':
+        print("here")
+        pron_dict = interface.get_pron_dict(request.json['pron_dict_name'])
+        print(request.json['pron_dict_name'])
+        model.link_pron_dict(pron_dict)
+        app.config['CURRENT_PRON_DICT'] = pron_dict
+        model.build_kaldi_structure()
+
     app.config['CURRENT_MODEL'] = model
     data = {
         "config": model.config._load()

--- a/elpis/engines/common/objects/interface.py
+++ b/elpis/engines/common/objects/interface.py
@@ -220,7 +220,8 @@ class Interface(FSObject):
         hash_dir = self.config['models'][mname]
         m = self.engine.model.load(self.models_path.joinpath(hash_dir))
         m.dataset = self.get_dataset(m.config['dataset_name'])
-        m.pron_dict = self.get_pron_dict(m.config['pron_dict_name'])
+        if m.config['pron_dict_name'] is not None:
+            m.pron_dict = self.get_pron_dict(m.config['pron_dict_name'])
         return m
 
     def list_models(self):

--- a/elpis/engines/common/objects/model.py
+++ b/elpis/engines/common/objects/model.py
@@ -4,7 +4,6 @@ from typing import Optional, Tuple, Dict
 from elpis.engines.common.objects.dataset import Dataset
 from elpis.engines.common.objects.fsobject import FSObject
 from elpis.engines.common.objects.path_structure import PathStructure
-from elpis.engines.common.objects.pron_dict import PronDict
 
 
 class ModelFiles(object):
@@ -63,8 +62,6 @@ class Model(FSObject):  # TODO not thread safe
             stage_status.update({stage_file: {'name': stage_name, 'status': 'ready', 'message': ''}})
             self.config['stage_status'] = stage_status
 
-    def link(self, dataset: Dataset, pron_dict: PronDict):
+    def link_dataset(self, dataset: Dataset):
         self.dataset = dataset
         self.config['dataset_name'] = dataset.name
-        self.pron_dict = pron_dict
-        self.config['pron_dict_name'] = pron_dict.name

--- a/elpis/engines/kaldi/objects/model.py
+++ b/elpis/engines/kaldi/objects/model.py
@@ -46,9 +46,8 @@ class KaldiModel(BaseModel):  # TODO not thread safe
     def has_been_trained(self):
         return self.status == 'trained'
 
-    def link(self, dataset: Dataset, pron_dict: PronDict):
-        self.dataset = dataset
-        self.config['dataset_name'] = dataset.name
+    def link_pron_dict(self, pron_dict: PronDict):
+        print("**** linking Kaldi model with pron dict")
         self.pron_dict = pron_dict
         self.config['pron_dict_name'] = pron_dict.name
 

--- a/elpis/engines/kaldi/objects/model.py
+++ b/elpis/engines/kaldi/objects/model.py
@@ -47,7 +47,6 @@ class KaldiModel(BaseModel):  # TODO not thread safe
         return self.status == 'trained'
 
     def link_pron_dict(self, pron_dict: PronDict):
-        print("**** linking Kaldi model with pron dict")
         self.pron_dict = pron_dict
         self.config['pron_dict_name'] = pron_dict.name
 


### PR DESCRIPTION
This is a stop-gap for new models to use pron-dicts for Kaldi engines, and datasets for non-kaldi engines.  There's a corresponding branch on the gui. 

Prior to the work, when making a new model the user could select a pron-dict, each of which is coupled to a dataset. For engines that don't use pron dicts, there was no mechanism to select a dataset.

The goal of this work was to base the creation of a model on either
1) a pron dict if using kaldi, or
2) on a dataset if using other engines.

To add a ui element to select a dataset requires getting the list of dataset names from the API. I added a new endpoint that returns the names of all the datasets, the (names and corresponding dataset) for all the pron dicts, and the names of the models. The names of models isn't used, but added it for possible future use, could make a dashboard or something. I could have chained dataset-list and pron-dict-list API requests; or made one or the other request by checking the engine type in the redux stage, but thought it was neater to add the new endpoint.

The new model form now gets the object-names from the newly added endpoint and determines whether to show a dataset list or pron-dict list based on the engine type (in the Formik Form).

