### PR TITLE
Reset dataset annotation values when doing import

### DIFF
--- a/elpis/transformer/__init__.py
+++ b/elpis/transformer/__init__.py
@@ -247,13 +247,14 @@ class DataTransformerAbstractFactory:
 
         Store the decorated function as a callback to process files with the
         given extention. The parameter to the decorator is the file extention.
-        The decorated function (f) should always have four parameters, being:
+        The decorated function (f) should always have five parameters, being:
             1. List containing the file paths of all the files in the import
                 directory with the specified extention.
             2. A dictionary context variable that can be used to access
                 specialised settings.
-            3. A callback to add annotation data to audio files.
-            4. Path to a temporary directory
+            3. A callback to reset annotation data.
+            4. A callback to add annotation data to audio files.
+            5. Path to a temporary directory
         
         This decorator is indended for the (audio file, transcription file)
         unique distinct pair usecase.
@@ -288,8 +289,8 @@ class DataTransformerAbstractFactory:
                 raise NameError('bad function name. Name is attribute of DataTransformer')
 
             sig = signature(f)
-            if len(sig.parameters) != 4:
-                raise RuntimeError(f'import function "{f.__name__}" must have four parameters, currently has {len(sig.parameters)}')
+            if len(sig.parameters) != 5:
+                raise RuntimeError(f'import function "{f.__name__}" must have five parameters, currently has {len(sig.parameters)}')
 
             # Store the closure by file extention
             self._import_extension_callbacks[extention] = f
@@ -597,6 +598,11 @@ class DataTransformerAbstractFactory:
         )
 
         # Callbacks to add data to the internal stores
+        def reset_annotations():
+            nonlocal dt
+            dt._annotation_store = {}
+            return
+
         def add_annotation(id, obj):
             nonlocal dt
             # check the object type
@@ -622,6 +628,7 @@ class DataTransformerAbstractFactory:
                 nonlocal dt
                 nonlocal f
                 nonlocal collection_path
+                nonlocal reset_annotations
                 nonlocal add_annotation
                 nonlocal add_audio
                 nonlocal temporary_directory_path
@@ -629,6 +636,7 @@ class DataTransformerAbstractFactory:
                     collection_path,
                     # resampled_path, # TODO: this line needs to be here so add the parameter to tests
                     copyJSONable(dt.get_settings()),
+                    reset_annotations,
                     add_annotation,
                     add_audio,
                     temporary_directory_path
@@ -672,11 +680,13 @@ class DataTransformerAbstractFactory:
                     """
                     nonlocal dt
                     nonlocal f
+                    nonlocal reset_annotations
                     nonlocal add_annotation
                     nonlocal temporary_directory_path
                     return f(
                         file_paths,
                         copyJSONable(dt.get_settings()),
+                        reset_annotations,
                         add_annotation,
                         temporary_directory_path
                     )
@@ -696,6 +706,7 @@ class DataTransformerAbstractFactory:
                 nonlocal dt
                 nonlocal collection_path
                 nonlocal resampled_path
+                nonlocal reset_annotations
                 nonlocal add_annotation
                 nonlocal add_audio
                 nonlocal temporary_directory_path
@@ -715,7 +726,7 @@ class DataTransformerAbstractFactory:
                     # only process the file type collection if a handler exists for it
                     callback = import_extension_callbacks.get(extention, None)
                     if callback is not None:
-                        callback(file_paths, dt.get_settings(), add_annotation, temporary_directory_path)
+                        callback(file_paths, dt.get_settings(), reset_annotations, add_annotation, temporary_directory_path)
 
                 # save transcription data to file
                 with Path(transcription_json_file_path).open(mode='w') as fout:

--- a/elpis/transformer/elan.py
+++ b/elpis/transformer/elan.py
@@ -140,7 +140,7 @@ def update_ui(file_paths: List[Path], ui):
     return ui
 
 @elan.import_files('eaf')
-def import_eaf_file(eaf_paths, context, add_annotation, tmp_dir):
+def import_eaf_file(eaf_paths, context, reset_annotations, add_annotation, tmp_dir):
     """
     Import handler for processing all .wav and .eaf files.
 
@@ -170,6 +170,8 @@ def import_eaf_file(eaf_paths, context, add_annotation, tmp_dir):
     # Convert dirty words and tokens from str to set, split by '\n'
     special_cases = set(context['special_cases'].splitlines())
     translation_tags = set(context['translation_tags'].splitlines())
+
+    reset_annotations()
 
     for input_elan_file in eaf_paths:
         # Get paths to files


### PR DESCRIPTION
If I make a new dataset, add files, choose a tier name (eg animals), build wordlist (eg the result is cat, dog, mouse). 

Go back to change tier name (eg birds) and go next to wordlist. I’d expect the wordlist to only show bird tier annotations (eg crow, magpie). 

However, it actually appends the desired annotations to the previous lot, (cat, dog, mouse, crow, magpie). 

This PR resets the transformer's `_annotation_store` each time import runs.


Please check that I added `reset_annotations` into the args lists where required, and I haven't put it anywhere it shouldn't be? 

Does import_directory need this too?