### PR TITLE
Bf subprocess

### DIFF
--- a/elpis/__init__.py
+++ b/elpis/__init__.py
@@ -32,6 +32,10 @@ def create_app(test_config=None):
                 static_folder=GUI_PUBLIC_DIR + static_dir,
                 static_url_path=static_dir)
 
+    import logging
+    log = logging.getLogger('werkzeug')
+    log.setLevel(logging.ERROR)
+
     # When making this multi-user, the secret key would require to be a secure hash.
     app.config.from_mapping(
         SECRET_KEY='dev'

--- a/elpis/endpoints/model.py
+++ b/elpis/endpoints/model.py
@@ -112,7 +112,7 @@ def train():
     if model is None:
         return jsonify({"status": 404,
                         "data": "No current model exists (perhaps create one first)"})
-    model.train(on_complete=lambda: print("Training complete!"))
+    model.train()
     data = {
         "status": model.status,
         "stage_status": model.stage_status

--- a/elpis/engines/common/objects/command.py
+++ b/elpis/engines/common/objects/command.py
@@ -11,9 +11,9 @@ def run(cmdline: str) -> subprocess.CompletedProcess:
     args = ['bash', '-c', cmdline]
     process = subprocess.run(
         args,
-        check=True,
+        check=False,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE,
         universal_newlines=True
     )
     return process

--- a/elpis/engines/common/objects/command.py
+++ b/elpis/engines/common/objects/command.py
@@ -1,19 +1,21 @@
 import subprocess
 
 
-def run(cmdline: str) -> subprocess.CompletedProcess:
+def run(cmdline: str, cwd: str = None) -> subprocess.CompletedProcess:
     """
     Run a command in the bash shell.
     
     :cmdline: command string to run in bash.
+    :cwd: optionallly, set the current working dir for the command.
     :return: the subprocess created from the string.
     """
     args = ['bash', '-c', cmdline]
     process = subprocess.run(
         args,
-        check=False,
+        check=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        universal_newlines=True
+        universal_newlines=True,
+        cwd=cwd
     )
     return process

--- a/elpis/engines/kaldi/inference/gmm-decode/9_ctm_output.sh
+++ b/elpis/engines/kaldi/inference/gmm-decode/9_ctm_output.sh
@@ -8,8 +8,7 @@
 export PATH=$PATH:/kaldi/src/online2bin
 
 # REPORT OUTPUT (CTM is the only concise format)
-echo "CTM output:"
+echo "==== CTM OUTPUT ===="
 cat ./data/infer/align-words-best-wordkeys.ctm
 
-echo "==== Output the words from the CTM file as plain text ===="
 awk 'BEGIN { ORS=" " }; { print $NF }' data/infer/align-words-best-wordkeys.ctm > data/infer/one-best-hypothesis.txt

--- a/elpis/engines/kaldi/templates/stages/0_setup.sh
+++ b/elpis/engines/kaldi/templates/stages/0_setup.sh
@@ -3,6 +3,10 @@
 . ./path.sh || exit 1
 . ./cmd.sh || exit 1
 
+echo
+echo "===== SETUP ====="
+echo
+
 nj=1       # number of parallel jobs - 1 is perfect for such a small data set
 lm_order=1 # language model order (n-gram quantity) - 1 is enough for digits grammar
 

--- a/elpis/transformer/__init__.py
+++ b/elpis/transformer/__init__.py
@@ -247,13 +247,14 @@ class DataTransformerAbstractFactory:
 
         Store the decorated function as a callback to process files with the
         given extention. The parameter to the decorator is the file extention.
-        The decorated function (f) should always have four parameters, being:
+        The decorated function (f) should always have five parameters, being:
             1. List containing the file paths of all the files in the import
                 directory with the specified extention.
             2. A dictionary context variable that can be used to access
                 specialised settings.
-            3. A callback to add annotation data to audio files.
-            4. Path to a temporary directory
+            3. A callback to reset annotation data.
+            4. A callback to add annotation data to audio files.
+            5. Path to a temporary directory
         
         This decorator is indended for the (audio file, transcription file)
         unique distinct pair usecase.
@@ -288,8 +289,8 @@ class DataTransformerAbstractFactory:
                 raise NameError('bad function name. Name is attribute of DataTransformer')
 
             sig = signature(f)
-            if len(sig.parameters) != 4:
-                raise RuntimeError(f'import function "{f.__name__}" must have four parameters, currently has {len(sig.parameters)}')
+            if len(sig.parameters) != 5:
+                raise RuntimeError(f'import function "{f.__name__}" must have five parameters, currently has {len(sig.parameters)}')
 
             # Store the closure by file extention
             self._import_extension_callbacks[extention] = f
@@ -597,6 +598,11 @@ class DataTransformerAbstractFactory:
         )
 
         # Callbacks to add data to the internal stores
+        def reset_annotations():
+            nonlocal dt
+            dt._annotation_store = {}
+            return
+
         def add_annotation(id, obj):
             nonlocal dt
             # check the object type
@@ -622,6 +628,7 @@ class DataTransformerAbstractFactory:
                 nonlocal dt
                 nonlocal f
                 nonlocal collection_path
+                nonlocal reset_annotations
                 nonlocal add_annotation
                 nonlocal add_audio
                 nonlocal temporary_directory_path
@@ -629,6 +636,7 @@ class DataTransformerAbstractFactory:
                     collection_path,
                     # resampled_path, # TODO: this line needs to be here so add the parameter to tests
                     copyJSONable(dt.get_settings()),
+                    reset_annotations,
                     add_annotation,
                     add_audio,
                     temporary_directory_path
@@ -672,11 +680,13 @@ class DataTransformerAbstractFactory:
                     """
                     nonlocal dt
                     nonlocal f
+                    nonlocal reset_annotations
                     nonlocal add_annotation
                     nonlocal temporary_directory_path
                     return f(
                         file_paths,
                         copyJSONable(dt.get_settings()),
+                        reset_annotations,
                         add_annotation,
                         temporary_directory_path
                     )
@@ -696,6 +706,7 @@ class DataTransformerAbstractFactory:
                 nonlocal dt
                 nonlocal collection_path
                 nonlocal resampled_path
+                nonlocal reset_annotations
                 nonlocal add_annotation
                 nonlocal add_audio
                 nonlocal temporary_directory_path
@@ -715,7 +726,7 @@ class DataTransformerAbstractFactory:
                     # only process the file type collection if a handler exists for it
                     callback = import_extension_callbacks.get(extention, None)
                     if callback is not None:
-                        callback(file_paths, dt.get_settings(), add_annotation, temporary_directory_path)
+                        callback(file_paths, dt.get_settings(), reset_annotations, add_annotation, temporary_directory_path)
 
                 # save transcription data to file
                 with Path(transcription_json_file_path).open(mode='w') as fout:

--- a/elpis/transformer/__init__.py
+++ b/elpis/transformer/__init__.py
@@ -598,6 +598,7 @@ class DataTransformerAbstractFactory:
         )
 
         # Callbacks to add data to the internal stores
+
         def reset_annotations():
             nonlocal dt
             dt._annotation_store = {}

--- a/elpis/transformer/elan.py
+++ b/elpis/transformer/elan.py
@@ -140,7 +140,7 @@ def update_ui(file_paths: List[Path], ui):
     return ui
 
 @elan.import_files('eaf')
-def import_eaf_file(eaf_paths, context, add_annotation, tmp_dir):
+def import_eaf_file(eaf_paths, context, reset_annotations, add_annotation, tmp_dir):
     """
     Import handler for processing all .wav and .eaf files.
 
@@ -170,6 +170,8 @@ def import_eaf_file(eaf_paths, context, add_annotation, tmp_dir):
     # Convert dirty words and tokens from str to set, split by '\n'
     special_cases = set(context['special_cases'].splitlines())
     translation_tags = set(context['translation_tags'].splitlines())
+
+    reset_annotations()
 
     for input_elan_file in eaf_paths:
         # Get paths to files


### PR DESCRIPTION
DONE:
minimised flask logging - all those status requests are noise. 

added individual stage logs, that are concatenated into train.log when it is all done (or if it fails) 

if run returns a 1 code, then break out of the stage sequence


NOTE: 
some of the kaldi programs output to stderr even though they seem like non-errors, so we can't just catch stderr message as indicating that a stage failed


TODO (one day): 
if we re-run training, the stage states should reset. currently the stages say complete when stages are re-running

Show log files in GUI