### PR TITLE
add training prep and train sub-function calls to model.train

### DIFF
--- a/elpis/engines/espnet/objects/model.py
+++ b/elpis/engines/espnet/objects/model.py
@@ -122,6 +122,10 @@ class EspnetModel(BaseModel):
 
         if on_complete is None:
             print("oncomplete is none")
+            self.status = 'training'
+            prepare_for_training()
+            train()
+            self.status = 'trained'
         else:
             print("oncomplete is not none")
             run_training_in_background()


### PR DESCRIPTION
Elpis version 0.94.4 had a lambda in the `model.train()` endpoint which caused the `objects.model.train()` to execute `run_training_in_background()` with threading.

Recently the lamba was removed, causing the objects train method to execute the code in the `if on-complete is None` block. In the espnet objects.model file, this was empty, so training didn't occur and the status remained "ready". 

This PR adds `prepare_for_training()` and `train()` sub-function calls into that block, setting status to "training" when it begins and sets `status` to "trained" when done. Same as the Kaldi object model train() block.
