### PR TITLE
Rearrange Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ Date is year-month-day format.
 - ESPnet
 
 ### Changed
-- Rearranged Dockerfile
 - Fixed changelog date for docs
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ Date is year-month-day format.
 
 
 ## [1.0.0] - 2020-09-20
+### Added
+- ESPnet
+
 ### Changed
+- Rearranged Dockerfile
 - Fixed changelog date for docs
 
 ## [0.94.6] - 2020-09-07

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,14 +125,6 @@ RUN echo "===> install ESPnet" && \
 
 WORKDIR /tmp
 
-# Add a task runner
-#RUN curl -s https://taskfile.org/install.sh | sh && mv ./bin/task /bin/
-
-# Add moustache templates as mo
-#RUN curl -sSO https://raw.githubusercontent.com/tests-always-included/mo/master/mo && \
-#    chmod +x mo && \
-#    mv mo /usr/local/bin
-
 # Add jq
 RUN wget https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
     chmod +x jq-linux64 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -208,8 +208,6 @@ RUN /usr/bin/python3 -m venv /venv
 
 ENV PATH="/venv/bin:$PATH"
 
-RUN apt-get update && apt-get install libffi-dev
-
 RUN pip3.6 install wheel pytest pylint && python setup.py develop
 
 WORKDIR /elpis

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 
 requirements = [dependency.strip() for dependency in open("requirements.txt", "r").readlines()]
 
-with open('README.md', 'r') as readme:
+with open('README.md', 'r', encoding="utf-8") as readme:
     long_description = readme.read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open('README.md', 'r') as readme:
 
 setup(
     name='elpis',
-    version='0.95.0',
+    version='0.95.1',
     packages=find_packages(),
     url='https://github.com/CoEDL/elpis',
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open('README.md', 'r') as readme:
 
 setup(
     name='elpis',
-    version='0.94.6',
+    version='0.95.0',
     packages=find_packages(),
     url='https://github.com/CoEDL/elpis',
     install_requires=requirements,


### PR DESCRIPTION
This rearranges the Dockerfile to group dependencies with engines and moves ESPnet install earlier in the layers. Also removes unused task runner and moustache template package.

More systematic formatting too.

I tried to remove the duplication of rows in setting ENV by replacing the non-interactive ones with `#RUN source $HOME/.bashrc` but that broke `python setup.py develop` later in the dockerfile. Maybe something in bashrc which changed paths? Simpler for now to leave the ENV duplication than to sort that out.

After building, I ran the image and succeeded in training and inferring with both Kaldi (with Abui) and ESPnet (with Na).