### PR TITLE
Support non-identical file names between .wav and .eaf, and recognise media offsets

### DIFF
--- a/elpis/transformer/elan.py
+++ b/elpis/transformer/elan.py
@@ -216,11 +216,14 @@ def import_eaf_file(eaf_paths: List[str],
             end = annotation[1]
             annotation = annotation[2]
 
+            time_origin = input_eaf.get_linked_files()[0].get("TIME_ORIGIN")
+            origin_offset = int(time_origin) if time_origin is not None else 0
+
             utterance = {
                 "audio_file_name": f"{file_name}.wav",
                 "transcript": annotation,
-                "start_ms": start,
-                "stop_ms": end,
+                "start_ms": start + origin_offset,
+                "stop_ms": end + origin_offset,
                 "speaker_id": speaker_id
             }
 

--- a/elpis/transformer/elan.py
+++ b/elpis/transformer/elan.py
@@ -219,8 +219,14 @@ def import_eaf_file(eaf_paths: List[str],
             time_origin = input_eaf.get_linked_files()[0].get("TIME_ORIGIN")
             origin_offset = int(time_origin) if time_origin is not None else 0
 
+            # If matching file, use that. Otherwise, fall back to the relative media url.
+            if os.path.isfile(f"{file_name}.wav"):
+                audio_file_name = f"{file_name}.wav"
+            else:
+                audio_file_name = input_eaf.get_linked_files()[0].get("RELATIVE_MEDIA_URL")
+
             utterance = {
-                "audio_file_name": f"{file_name}.wav",
+                "audio_file_name": audio_file_name,
                 "transcript": annotation,
                 "start_ms": start + origin_offset,
                 "stop_ms": end + origin_offset,


### PR DESCRIPTION
Resolves #191, #193.

This implementation doesn't give the user any choice as to whether to match the file name of the corresponding `.eaf` file or to just get it from `RELATIVE_MEDIA_URL`. It defaults to the former behaviour and falls back to the later.

This implementation also ignores `MEDIA_URL` as it is difficult to wrestle it (e.g. `"file:///Users/bbb/Desktop/abui/abui-audio-1.wav"`) into a format that the rest of the application will be able to handle easily. In other words, it assumes that `RELATIVE_MEDIA_URL` is well formed.

This also fixes any `line = wer_lines[0] IndexError: list index out of range` errors that may have been happening before, although please double check they are actually fixed.

Offsets are directly `int()`-ed from the `.eaf` file.