### PR TITLE
Ben infer files

### DIFF
--- a/elpis/endpoints/transcription.py
+++ b/elpis/endpoints/transcription.py
@@ -69,12 +69,17 @@ def text():
     })
 
 
-
 @bp.route("/elan", methods=['GET'])
 def elan():
     transcription: Transcription = app.config['CURRENT_TRANSCRIPTION']
-    # TODO fix this to return json wrapper
-    return transcription.elan()
+    data = {
+        "audio_filename": transcription.audio_filename,
+        "elan": transcription.elan()
+    }
+    return jsonify({
+        "status": 200,
+        "data": data
+    })
 
 
 @bp.route("/confidence", methods=['GET'])

--- a/elpis/endpoints/transcription.py
+++ b/elpis/endpoints/transcription.py
@@ -59,8 +59,15 @@ def status():
 @bp.route("/text", methods=['GET'])
 def text():
     transcription: Transcription = app.config['CURRENT_TRANSCRIPTION']
-    # TODO fix this to return json wrapper
-    return transcription.text()
+    data = {
+        "audio_filename": transcription.audio_filename,
+        "text": transcription.text()
+    }
+    return jsonify({
+        "status": 200,
+        "data": data
+    })
+
 
 
 @bp.route("/elan", methods=['GET'])

--- a/elpis/engines/common/objects/transcription.py
+++ b/elpis/engines/common/objects/transcription.py
@@ -17,6 +17,7 @@ class Transcription(FSObject):
         self.config['exporter'] = None
         self.config['has_been_transcribed'] = False
         self.config['stage_status'] = {}
+        self.audio_filename = None
 
     @classmethod
     def load(cls, base_path: Path):

--- a/elpis/engines/common/output/ctm_to_elan.py
+++ b/elpis/engines/common/output/ctm_to_elan.py
@@ -70,9 +70,9 @@ def create_eaf_and_textgrid(wav_dictionary:dict,
                ctm_dictionary:dict,
                confidence:bool,
                output_directory:str):
-    for index, [utterance_id, basename] in enumerate(wav_dictionary.items()):
+    for index, [utterance_id, audio_filename] in enumerate(wav_dictionary.items()):
         eaf = Eaf()
-        eaf.add_linked_file(str(Path(output_directory, basename)))
+        eaf.add_linked_file(audio_filename)
         eaf.add_linguistic_type("conf_lt", "Symbolic_Association")
         eaf.add_tier("default")
         if confidence:

--- a/elpis/engines/common/output/ctm_to_elan.py
+++ b/elpis/engines/common/output/ctm_to_elan.py
@@ -59,8 +59,9 @@ def get_segment_dictionary(segment_file_name: str) -> Dict[str, Tuple[str, float
 def wav_scp_to_dictionary(scp_file_name: str) -> dict:
     wav_dictionary = dict()
     with open(scp_file_name) as file:
-        wav_entries = list(reader(file, delimiter=" "))
-        for entry in wav_entries:
+        wav_entries = file.read().splitlines()
+        for line in wav_entries:
+            entry = line.split(" ", 1) # use 1 here in case wav filenames include spaces
             utterance_id = entry[0]
             wav_file_path = entry[1]
             wav_dictionary[utterance_id] = wav_file_path

--- a/elpis/engines/kaldi/inference/gmm-decode-conf/gmm-decode-conf.sh
+++ b/elpis/engines/kaldi/inference/gmm-decode-conf/gmm-decode-conf.sh
@@ -103,7 +103,8 @@ utils/int2sym.pl -f 5 \
 
 # Now, wav.scp needs to be in segment form
 # eg audio_id filename
-echo "decode audio.wav" > ./data/infer/split1/1/wav.scp
+audio_filename=$(<./data/infer/audio_meta.txt)
+echo "decode ${audio_filename}" > ./data/infer/split1/1/wav.scp
 
 echo "==== CTM output ===="
 awk  -F" " 'BEGIN { ORS=" " }; {print $(NF-1)}' \

--- a/elpis/engines/kaldi/inference/gmm-decode-online-conf/4_ctm_output.sh
+++ b/elpis/engines/kaldi/inference/gmm-decode-online-conf/4_ctm_output.sh
@@ -11,7 +11,8 @@ echo "==== CTM output ===="
 
 # Now, wav.scp needs to be in segment form
 # eg audio_id filename
-echo "decode audio.wav" > ./data/infer/split1/1/wav.scp
+audio_filename=$(<./data/infer/audio_meta.txt)
+echo "decode ${audio_filename}" > ./data/infer/split1/1/wav.scp
 
 awk  -F" " 'BEGIN { ORS=" " }; {print $(NF-1)}' \
   data/infer/ctm_with_conf.ctm \

--- a/elpis/engines/kaldi/objects/transcription.py
+++ b/elpis/engines/kaldi/objects/transcription.py
@@ -210,7 +210,7 @@ class KaldiTranscription(BaseTranscription):
             return fin.read()
 
     def elan(self):
-        with open(f'{self.path}/{self.hash}.eaf', 'rb') as fin:
+        with open(f'{self.path}/{self.hash}.eaf', 'r') as fin:
             return fin.read()
 
     def get_confidence(self):

--- a/elpis/engines/kaldi/objects/transcription.py
+++ b/elpis/engines/kaldi/objects/transcription.py
@@ -101,8 +101,15 @@ class KaldiTranscription(BaseTranscription):
         self.status = "transcribing"
         local_kaldi_path = self.model.path.joinpath('kaldi')
         kaldi_infer_path = self.model.path.joinpath('kaldi', 'data', 'infer')
+
+        print("========= reset kaldi infer dir")
+        # wipe the infer dir to clear previous audio and infer fiels
+        if kaldi_infer_path.exists():
+            shutil.rmtree(f'{kaldi_infer_path}')
+            kaldi_infer_path.mkdir(parents=True, exist_ok=True)
+
         print("========= reset exp dir")
-        # wipe previous dir to avoid file_exists errors
+        # wipe previous exp dir to avoid file_exists errors
         exp_path = self.model.path.joinpath('kaldi','exp','tri1_online')
         if exp_path.exists():
             shutil.rmtree(f'{exp_path}')
@@ -151,7 +158,6 @@ class KaldiTranscription(BaseTranscription):
         stage_count = 0
 
         # Build stage scripts
-        os.makedirs(f"{kaldi_infer_path}", exist_ok=True)
         dir_util.copy_tree(f'{self.path}', f"{kaldi_infer_path}")
         file_util.copy_file(f'{self.audio_file_path}', f"{self.model.path.joinpath('kaldi', self.audio_filename)}")
         # Copy parts of transcription process and chmod

--- a/elpis/gui/src/components/Transcription/New.js
+++ b/elpis/gui/src/components/Transcription/New.js
@@ -55,15 +55,18 @@ class NewTranscription extends Component {
     }
 
     handleDownloadText = () => {
-        const {audio_filename, text} = this.props;
-        const audio_base_name = audio_filename.replace(/\.[^/.]+$/, "");
-        const text_file_name = audio_base_name + ".txt";
+        const {filename, text} = this.props;
+        const file_basename = filename.split(".").slice(0, -1).join(".");
+        const text_file_name = file_basename + ".txt";
 
         downloadjs(text, text_file_name, "text/txt");
     }
 
     handleDownloadElan = () => {
-        downloadjs(this.props.elan, "elan.eaf", "text/xml");
+        const {filename, elan} = this.props;
+        const file_basename = filename.split(".").slice(0, -1).join(".");
+
+        downloadjs(elan, file_basename + ".eaf", "text/xml");
     }
 
     onDrop = (acceptedFiles) => {
@@ -254,7 +257,6 @@ const mapStateToProps = state => {
         filename: state.transcription.filename,
         status: state.transcription.status,
         stage_status: state.transcription.stage_status,
-        audio_filename: state.transcription.audio_filename,
         text: state.transcription.text,
         elan: state.transcription.elan,
         confidence: state.transcription.confidence,

--- a/elpis/gui/src/components/Transcription/New.js
+++ b/elpis/gui/src/components/Transcription/New.js
@@ -55,7 +55,11 @@ class NewTranscription extends Component {
     }
 
     handleDownloadText = () => {
-        downloadjs(this.props.text, "text.txt", "text/txt");
+        const {audio_filename, text} = this.props;
+        const audio_base_name = audio_filename.replace(/\.[^/.]+$/, "");
+        const text_file_name = audio_base_name + ".txt";
+
+        downloadjs(text, text_file_name, "text/txt");
     }
 
     handleDownloadElan = () => {
@@ -87,9 +91,6 @@ class NewTranscription extends Component {
 
     render = () => {
         const {t, currentEngine, filename, list, status, stage_status, confidence, modelName} = this.props;
-
-        console.log(confidence);
-
         const {uploading, show_confidence_opacity} = this.state;
         const listTrained = list.filter(model => model.status === "trained");
         const listOptions = listTrained.map(model => ({
@@ -253,6 +254,7 @@ const mapStateToProps = state => {
         filename: state.transcription.filename,
         status: state.transcription.status,
         stage_status: state.transcription.stage_status,
+        audio_filename: state.transcription.audio_filename,
         text: state.transcription.text,
         elan: state.transcription.elan,
         confidence: state.transcription.confidence,

--- a/elpis/gui/src/redux/reducers/transcriptionReducer.js
+++ b/elpis/gui/src/redux/reducers/transcriptionReducer.js
@@ -8,6 +8,7 @@ const initState = {
     text: null,
     elan: null,
     confidence: null,
+    audio_filename: null,
 };
 const transcription = (state = initState, action) => {
     switch (action.type) {
@@ -29,8 +30,9 @@ const transcription = (state = initState, action) => {
             return {...state, status, stage_status, type};
 
         case actionTypes.TRANSCRIPTION_GET_TEXT_SUCCESS:
-            // The response here is the file data, not wrapped in a JSON data/status format
-            return {...state, text: action.response.data};
+            var {audio_filename, text} = action.response.data.data;
+
+            return {...state, audio_filename, text};
 
         case actionTypes.TRANSCRIPTION_GET_ELAN_SUCCESS:
             // The response here is the file data, not wrapped in a JSON data/status format

--- a/elpis/gui/src/redux/reducers/transcriptionReducer.js
+++ b/elpis/gui/src/redux/reducers/transcriptionReducer.js
@@ -8,9 +8,9 @@ const initState = {
     text: null,
     elan: null,
     confidence: null,
-    audio_filename: null,
 };
 const transcription = (state = initState, action) => {
+
     switch (action.type) {
         case actionTypes.TRANSCRIPTION_NEW_SUCCESS:
             var {originalFilename} = action.response.data.data;
@@ -30,13 +30,10 @@ const transcription = (state = initState, action) => {
             return {...state, status, stage_status, type};
 
         case actionTypes.TRANSCRIPTION_GET_TEXT_SUCCESS:
-            var {audio_filename, text} = action.response.data.data;
-
-            return {...state, audio_filename, text};
+            return {...state, text: action.response.data.data.text};
 
         case actionTypes.TRANSCRIPTION_GET_ELAN_SUCCESS:
-            // The response here is the file data, not wrapped in a JSON data/status format
-            return {...state, elan: action.response.data};
+            return {...state, elan: action.response.data.data.elan};
 
         case actionTypes.TRANSCRIPTION_GET_CONFIDENCE_SUCCESS:
             var {confidence} = action.response.data.data;


### PR DESCRIPTION
Current inferencing scripts rename untranscribed audio files to `audio.wav`. The linked audio file in the Elan output file is a rel path to where the elan file was created in the Kaldi dir. Opening the generated Elan output file requires manually relinking audio. 

Would be better if the audio file name was kept throughout, to save relinking files when reviewing the output. 

The changes in this PR percolate the audio filename through the process, using it in the Elan linked media field, and naming the text and elan files with the same basename. 

Leaving the ESPnet engine as using `audio.wav`. Hopefully the HFT work will be done soon and ESPnet removed. Not worth the bother of trying to get it running to check any changes to that engine.