### PR TITLE
(WIP) cli examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -194,11 +194,16 @@ WORKDIR /elpis-gui
 RUN yarn install && \
     yarn run build
 
-WORKDIR /tmp
+WORKDIR /
 
-# Example data
+# Sample data for command line interaction with Elpis
+WORKDIR /
 RUN git clone --depth=1 https://github.com/CoEDL/toy-corpora.git
-
+RUN git clone --depth=1 https://github.com/CoEDL/timit-elan.git
+WORKDIR /datasets
+RUN ln -s /toy-corpora/abui /datasets/abui
+RUN ln -s /toy-corpora/na /datasets/na
+RUN ln -s /timit-elan /datasets/timit
 
 ########################## RUN THE APP ##########################
 

--- a/docs/wiki/elpis-cli.md
+++ b/docs/wiki/elpis-cli.md
@@ -34,16 +34,18 @@ docker run --rm -it -p 5001:5001/tcp -v ~/Desktop/datasets:/datasets --entrypoin
 ```
 
 
-In the container, run the Python training script. It will look in the folder you gave, train a system based on the audio and text files it finds, and transcribe the untranscribed audio.
+In the container, set up a virtual environment and install dependencies. Then run the sample Python training script. It will look in the folder you gave, train a system based on the audio and text files it finds, and transcribe the untranscribed audio.
 
-We have a demo script you can try. Base your own training script on this example.
+Base your own training script on the example script.
 
 ```
+cd /elpis
+poetry shell
 python elpis/examples/cli/kaldi/train.py
 ```
 
 
-Use the trained model to transcribe some audio.
+Or, use a trained model to transcribe some audio.
 
 ```
 python elpis/examples/cli/kaldi/transcribe.py

--- a/elpis/examples/cli/hft/train.py
+++ b/elpis/examples/cli/hft/train.py
@@ -13,6 +13,7 @@ docker run --rm -it -p 5001:5001/tcp \
 Change dataset dir values etc below to suit your data.
 Run the data preparation scripts and do training by calling this script from the /elpis dir.
 
+poetry shell
 python elpis/examples/cli/hft/train.py
 """
 
@@ -46,13 +47,13 @@ elpis.set_engine(engine)
 # Setup a dataset to to train data on.
 # Reuse dataset if it exists
 if DATASET_NAME not in elpis.list_datasets():
-    ds = elpis.new_dataset(DATASET_NAME)
-    ds.add_directory(DATASET_DIR, extensions=['eaf', 'wav'])
-    ds.auto_select_importer() # Selects Elan because of eaf file.
-    ds.importer.set_setting(IMPORTER_METHOD, IMPORTER_VALUE)
-    ds.process()
+    dataset = elpis.new_dataset(DATASET_NAME)
+    dataset.add_directory(DATASET_DIR, extensions=['eaf', 'wav'])
+    dataset.auto_select_importer() # Selects Elan because of eaf file.
+    dataset.importer.set_setting(IMPORTER_METHOD, IMPORTER_VALUE)
+    dataset.process()
 else:
-    ds = elpis.get_dataset(DATASET_NAME)
+    dataset = elpis.get_dataset(DATASET_NAME)
 
 
 # Step 3
@@ -62,11 +63,11 @@ i = 0
 while MODEL_NAME in elpis.list_models():
     MODEL_NAME = MODEL_NAME + str(i)
 print('Making new model', MODEL_NAME)
-m = elpis.new_model(MODEL_NAME)
-print('Made model', m.hash)
+model = elpis.new_model(MODEL_NAME)
+print('Made model', model.hash)
 print('Linking dataset')
-m.link_dataset(ds)
+model.link_dataset(dataset)
 print('Start training. This may take a while')
-m.train()
+model.train()
 
 # TODO infer

--- a/elpis/examples/cli/kaldi/train.py
+++ b/elpis/examples/cli/kaldi/train.py
@@ -13,6 +13,7 @@ docker run --rm -it -p 5001:5001/tcp \
 Change dataset dir values etc below to suit your data.
 Run the data preparation scripts and do training by calling this script from the /elpis dir.
 
+poetry shell
 python elpis/examples/cli/kaldi/train.py
 """
 
@@ -51,14 +52,14 @@ elpis.set_engine(engine)
 # Reuse dataset if it exists
 if DATASET_NAME not in elpis.list_datasets():
     print("Making new dataset")
-    ds = elpis.new_dataset(DATASET_NAME)
-    ds.add_directory(DATASET_DIR, extensions=['eaf', 'wav'])
-    ds.auto_select_importer() # Selects Elan because of eaf file.
-    ds.importer.set_setting(IMPORTER_METHOD, IMPORTER_VALUE)
-    ds.process()
+    dataset = elpis.new_dataset(DATASET_NAME)
+    dataset.add_directory(DATASET_DIR, extensions=['eaf', 'wav'])
+    dataset.auto_select_importer() # Selects Elan because of eaf file.
+    dataset.importer.set_setting(IMPORTER_METHOD, IMPORTER_VALUE)
+    dataset.process()
 else:
     print("Use existing dataset")
-    ds = elpis.get_dataset(DATASET_NAME)
+    dataset = elpis.get_dataset(DATASET_NAME)
 
 
 # Step 3
@@ -67,13 +68,13 @@ else:
 # Reuse pronunciation dictionary if it exists
 if PRON_DICT_NAME not in elpis.list_pron_dicts():
     print("Making new pron dict")
-    pd = elpis.new_pron_dict(PRON_DICT_NAME)
-    pd.link(ds)
-    pd.set_l2s_path(L2S_PATH)
-    pd.generate_lexicon()
+    pron_dict = elpis.new_pron_dict(PRON_DICT_NAME)
+    pron_dict.link(dataset)
+    pron_dict.set_l2s_path(L2S_PATH)
+    pron_dict.generate_lexicon()
 else:
     print("Use existing pron dict")
-    pd = elpis.get_pron_dict(PRON_DICT_NAME)
+    pron_dict = elpis.get_pron_dict(PRON_DICT_NAME)
 
 
 # Step 4
@@ -82,25 +83,26 @@ else:
 # Load model if it exists
 if MODEL_NAME not in elpis.list_models():
     print("Making new model")
-    m = elpis.new_model(MODEL_NAME)
-    m.link_dataset(ds)
-    m.link_pron_dict(pd)
-    m.build_structure()
-    m.train() # may take a while
+    model = elpis.new_model(MODEL_NAME)
+    model.link_dataset(dataset)
+    model.link_pron_dict(pron_dict)
+    model.build_structure()
+    model.train() # may take a while
 else:
     print("Use existing model")
-    m = elpis.get_model(MODEL_NAME)
+    model = elpis.get_model(MODEL_NAME)
 
 
 # Step 5
 # ======
 # Make a transcription interface and transcribe audio.
-i = 0
-while TX_NAME in elpis.list_transcriptions():
-    TX_NAME = TX_NAME + str(i)
-t = elpis.new_transcription(TX_NAME)
-t.link(m)
-with open(INFER_FILE_PATH, 'rb') as faudio:
-    t.prepare_audio(faudio)
-t.transcribe()
-print(t.text())
+# TODO fix this .. prepare_audio expects a request.file object
+# i = 0
+# while TX_NAME in elpis.list_transcriptions():
+#     TX_NAME = TX_NAME + str(i)
+# transcription = elpis.new_transcription(TX_NAME)
+# transcription.link(model)
+# with open(INFER_FILE_PATH, 'rb') as faudio:
+#     transcription.prepare_audio(faudio,  on_complete=lambda: print('Prepared audio file!'))
+# transcription.transcribe()
+# print(transcription.text())

--- a/elpis/examples/cli/kaldi/train.py
+++ b/elpis/examples/cli/kaldi/train.py
@@ -91,18 +91,3 @@ if MODEL_NAME not in elpis.list_models():
 else:
     print("Use existing model")
     model = elpis.get_model(MODEL_NAME)
-
-
-# Step 5
-# ======
-# Make a transcription interface and transcribe audio.
-# TODO fix this .. prepare_audio expects a request.file object
-# i = 0
-# while TX_NAME in elpis.list_transcriptions():
-#     TX_NAME = TX_NAME + str(i)
-# transcription = elpis.new_transcription(TX_NAME)
-# transcription.link(model)
-# with open(INFER_FILE_PATH, 'rb') as faudio:
-#     transcription.prepare_audio(faudio,  on_complete=lambda: print('Prepared audio file!'))
-# transcription.transcribe()
-# print(transcription.text())

--- a/elpis/examples/cli/kaldi/transcribe.py
+++ b/elpis/examples/cli/kaldi/transcribe.py
@@ -20,14 +20,15 @@ elpis.set_engine(engine)
 # Step 2
 # ======
 # Load Model
-m = elpis.get_model(MODEL_NAME)
+model = elpis.get_model(MODEL_NAME)
 
 # Step 3
 # ======
-# Make a transcription interface and transcribe unseen audio to elan.
-t = elpis.new_transcription(TX_NAME)
-t.link(m)
-with open(INFER_FILE_PATH, 'rb') as faudio:
-    t.prepare_audio(faudio)
-t.transcribe()
-print(t.text())
+# Make a transcription interface and transcribe audio.
+# TODO fix this .. prepare_audio expects a request.file object
+# transcription.link(model)
+# transcription = elpis.new_transcription(TX_NAME)
+# with open(INFER_FILE_PATH, 'rb') as faudio:
+#     transcription.prepare_audio(faudio)
+# transcription.transcribe()
+# print(transcription.text())


### PR DESCRIPTION
The PR updates the sample Python scripts for CLI interaction with Elpis. Kaldi and HFT engines are demonstrated for dataset prep and training. 

Includes update to Dockerfile to ship timit corpus in the image.

Transcription fails due to transcription.prepare_audio expecting a Request.file dict type object. Old CLI sample code was passing a binary file object.

