### PR TITLE
Hft audio slice

### DIFF
--- a/elpis/examples/cli/hft/train.py
+++ b/elpis/examples/cli/hft/train.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import os
 
 
-USE_DATASET = 'timit'
+USE_DATASET = 'gk'
 
 if USE_DATASET == 'gk':
     DATASET_DIR = '/datasets/gk'


### PR DESCRIPTION
For datasets containing Elan files with multiple annotations per file, HFT speech preparation was inefficiently resampling the audio multiple times. This loads only the relevant slices of audio for each annotation.