### PR TITLE
Speed up resetting procedure

### DIFF
--- a/docs/wiki/viewing-elpis-training-log-file.md
+++ b/docs/wiki/viewing-elpis-training-log-file.md
@@ -34,9 +34,9 @@ docker exec -it CONTAINER_ID bash
 5. Or use this one-liner: `docker exec -it $(docker ps -q) bash`
 
 
-6. Look in the `/state/models` directory. The hashes are directories of the models that have been made. Change into the current model dir. 
+6. Look in the `/state/of_origin/models` directory. The hashes are directories of the models that have been made. Change into the current model dir. 
 ```shell
-cd /state/models
+cd /state/of_origin/models
 ls
 cd XXXX
 ```

--- a/elpis/__init__.py
+++ b/elpis/__init__.py
@@ -64,7 +64,7 @@ def create_app(test_config=None):
     # the app.config, however, this would need to change for multi-user.
     # Each user would require a unique Interface. One Interface
     # stores all the artifacts that user has generated.
-    interface_path = Path(os.path.join(elpis_path, '/state'))
+    interface_path = Path(os.path.join(elpis_path, '/state/of_origin'))
     if not interface_path.exists():
         app.config['INTERFACE'] = Interface(interface_path)
     else:
@@ -90,7 +90,7 @@ def create_app(test_config=None):
             print('Tensorboard is not running, start it')
             tensorboard = program.TensorBoard()
             tensorboard.configure(argv=['tensorboard',
-                                        '--logdir=/state/models',
+                                        '--logdir=/state/of_origin/models',
                                         '--port=6006',
                                         '--host=0.0.0.0'])
             url = tensorboard.launch()

--- a/elpis/engines/common/objects/interface.py
+++ b/elpis/engines/common/objects/interface.py
@@ -53,7 +53,7 @@ class Interface(FSObject):
                 and path.is_dir()
                 and config_file_path.exists()
                 and config_file_path.is_file()):
-                # a valid interface exists. (this is a shallow check)
+                    # a valid interface exists. (this is a shallow check)
                     pass
             else:
                 raise InvalidInterfaceError
@@ -62,24 +62,10 @@ class Interface(FSObject):
         except InvalidInterfaceError:
             # Must wipe the interface and make a new one
             if path.exists():
-                # Tempted to use shutil.rmtree? It breaks if we have mounted /state from
-                # local filesystem into the docker container.
-                # Error is "Device or resource busy: '/state'"
-                # We need to keep the dir and delete the contents...
-                for root, subdirectories, files in os.walk(path):
-                    for file_ in files:
-                        # Move to a different directory for the time being
-                        deletion_path = os.path.join(root, f"{file_}_old")
-                        shutil.move(os.path.join(root, file_), deletion_path)
-                        # Delete in the background
-                        subprocess.Popen(["rm", "-r", deletion_path])
-                    for directory in subdirectories:
-                        # Move to a different directory for the time being
-                        deletion_path = os.path.join(root, f"{directory}_old")
-                        shutil.move(os.path.join(root, directory), deletion_path)
-                        # Delete in the background
-                        subprocess.Popen(["rm", "-r", deletion_path])
-                
+                deletion_path = Path('/state/tmp')
+                path.rename(deletion_path)
+                # Delete in the background
+                subprocess.Popen(["rm", "-r", deletion_path])
 
             super().__init__(
                 parent_path=path.parent,

--- a/elpis/engines/common/objects/interface.py
+++ b/elpis/engines/common/objects/interface.py
@@ -2,6 +2,7 @@ import json
 import os
 from pathlib import Path
 import shutil
+import subprocess
 import re
 
 from appdirs import user_data_dir
@@ -67,9 +68,18 @@ class Interface(FSObject):
                 # We need to keep the dir and delete the contents...
                 for root, subdirectories, files in os.walk(path):
                     for file_ in files:
-                        os.unlink(os.path.join(root, file_))
+                        # Move to a different directory for the time being
+                        deletion_path = os.path.join(root, f"{file_}_old")
+                        shutil.move(os.path.join(root, file_), deletion_path)
+                        # Delete in the background
+                        subprocess.Popen(["rm", "-r", deletion_path])
                     for directory in subdirectories:
-                        shutil.rmtree(os.path.join(root, directory))
+                        # Move to a different directory for the time being
+                        deletion_path = os.path.join(root, f"{directory}_old")
+                        shutil.move(os.path.join(root, directory), deletion_path)
+                        # Delete in the background
+                        subprocess.Popen(["rm", "-r", deletion_path])
+                
 
             super().__init__(
                 parent_path=path.parent,

--- a/elpis/examples/cli/hft/create_dataset.py
+++ b/elpis/examples/cli/hft/create_dataset.py
@@ -34,7 +34,7 @@ def main(dataset_name: str, reset: bool):
     # ======
     # Use or create the Elpis interface directory where all the associated files/objects are stored.
     print('Create interface')
-    elpis = Interface(path=Path('/state'), use_existing=reset)
+    elpis = Interface(path=Path('/state/of_origin'), use_existing=reset)
 
     # Step 1
     # ======

--- a/elpis/examples/cli/hft/train.py
+++ b/elpis/examples/cli/hft/train.py
@@ -30,7 +30,7 @@ def main(dataset_name: str, reset: bool):
     # ======
     # Use or create the Elpis interface directory where all the associated files/objects are stored.
     print('Create interface')
-    elpis = Interface(path=Path('/state'), use_existing=reset)
+    elpis = Interface(path=Path('/state/of_origin'), use_existing=reset)
 
     # Step 1
     # ======
@@ -72,9 +72,9 @@ def main(dataset_name: str, reset: bool):
     # TODO add model settings
     print('Linking dataset')
     model.link_dataset(dataset)
-    if Path('/state/models/latest').is_dir():
-        os.remove('/state/models/latest')
-    os.symlink(f'/state/models/{model.hash}', '/state/models/latest', target_is_directory=True)
+    if Path('/state/of_origin/models/latest').is_dir():
+        os.remove('/state/of_origin/models/latest')
+    os.symlink(f'/state/of_origin/models/{model.hash}', '/state/of_origin/models/latest', target_is_directory=True)
     print('Start training. This may take a while')
     model.train()
 

--- a/elpis/examples/cli/hft/transcribe.py
+++ b/elpis/examples/cli/hft/transcribe.py
@@ -14,7 +14,7 @@ def main(model_name: str, infer_path: str):
     # ======
     # Use the Elpis interface directory where all the associated files/objects are stored.
     print('Create interface')
-    elpis = Interface(path=Path('/state'), use_existing=True)
+    elpis = Interface(path=Path('/state/of_origin'), use_existing=True)
 
     # Step 1
     # ======
@@ -44,10 +44,10 @@ def main(model_name: str, infer_path: str):
     print('Linking model')
     transcription.link(model)
 
-    if Path('/state/transcriptions/latest').is_dir():
-        os.remove('/state/transcriptions/latest')
-    os.symlink(f'/state/transcriptions/{transcription.hash}',
-               '/state/transcriptions/latest',
+    if Path('/state/of_origin/transcriptions/latest').is_dir():
+        os.remove('/state/of_origin/transcriptions/latest')
+    os.symlink(f'/state/of_origin/transcriptions/{transcription.hash}',
+               '/state/of_origin/transcriptions/latest',
                target_is_directory=True)
 
     print(f'Load audio from {infer_path}')

--- a/elpis/examples/cli/kaldi/train.py
+++ b/elpis/examples/cli/kaldi/train.py
@@ -35,7 +35,7 @@ INFER_FILE_PATH = '/datasets/abui/untranscribed/audio.wav'
 # ======
 # Create a Kaldi interface directory (where all the associated files/objects
 # will be stored).
-elpis = Interface(path=Path('/state'), use_existing=True)
+elpis = Interface(path=Path('/state/of_origin'), use_existing=True)
 
 
 # Step 1

--- a/elpis/examples/cli/kaldi/transcribe.py
+++ b/elpis/examples/cli/kaldi/transcribe.py
@@ -8,7 +8,7 @@ INFER_FILE_PATH = '/datasets/abui/untranscribed/audio.wav'
 # ======
 # Create a Kaldi interface directory (where all the associated files/objects
 # will be stored).
-elpis = Interface(path='/state', use_existing=True)
+elpis = Interface(path='/state/of_origin', use_existing=True)
 
 # Step 1
 # ======


### PR DESCRIPTION
When the Reset button is clicked, currently the app must wait for the `/state` directory to be cleared before proceeding. This can be disruptive for large datasets with gigabytes of files to be deleted. This PR makes it so that the files are first moved out of the state folder (quicker) before being actually deleted in the background, which should be faster.

I tried using `rsync` but it led to some race condition issues (deleting after dataset and interface are re-initialised). The moving approach is safest.

Benchmark on ~848MB of files from the gk dataset:

- Old approach: `0.31405` seconds
- New approach: `0.16623` seconds