### PR TITLE
prevent selection mechanism failure

### DIFF
--- a/elpis/gui/src/components/Dataset/GeneratedUI.js
+++ b/elpis/gui/src/components/Dataset/GeneratedUI.js
@@ -27,7 +27,7 @@ const GeneratedUI = ({props, settings, ui, changeSettingsCallback}) => {
 
     // On initialisation of component, show the tier name and set it properly
     useEffect(() => {
-        if (settings !== null) {
+        if (settings && settings["selection_mechanism"]) {
             const selection_mechanism = settings["selection_mechanism"];
 
             ui["data"][selection_mechanism]["shown"] = true;


### PR DESCRIPTION
Dataset importer settings are determined by reading Elan files to get tier info. If a WAV file is dropped into the file upload widget first, the no imported settings are returned from the backend. The frontend was expecting a `null` object but it was actually `undefined`. This is a quick fix to prevent the selection mechanism code from running if the setting is undefined.