### PR TITLE
Fix Kaldi stage_status num of args error

### DIFF
--- a/elpis/engines/common/objects/model.py
+++ b/elpis/engines/common/objects/model.py
@@ -59,6 +59,7 @@ class Model(FSObject):  # TODO not thread safe
 
     @stage_status.setter
     def stage_status(self, status_info: Tuple[str, str]):
+        # Caution: stage_status in the model accepts two args. Transcriber's stage_status accepts three.
         stage, status = status_info
         stage_status = self.config["stage_status"]
         stage_status[stage]["status"] = status

--- a/elpis/engines/common/objects/transcription.py
+++ b/elpis/engines/common/objects/transcription.py
@@ -49,6 +49,7 @@ class Transcription(FSObject):
 
     @stage_status.setter
     def stage_status(self, vals: Tuple[str, str, str]):
+        # Caution: stage_status in the transcriber accepts three args. Model's stage_status only accepts two.
         stage, status, message = vals
         stage_status = self.config["stage_status"]
         stage_status[stage]["status"] = status

--- a/elpis/engines/kaldi/objects/model.py
+++ b/elpis/engines/kaldi/objects/model.py
@@ -263,7 +263,7 @@ class KaldiModel(BaseModel):  # TODO not thread safe
                         print("stderr", error.stderr, file=file)
                         print("failed", file=file)
                     logger.error(f"Stage {stage} failed")
-                    self.stage_status = (stage, "failed", "", "LOG-C")
+                    self.stage_status = (stage, "failed")
                     break
 
         def run_training_in_background():


### PR DESCRIPTION
When a Kaldi training stage failed, log reporting failed because stage_status had too many args. Should only have the stage name and status, but it also had some others. Must have been legacy code that didn't get updated in the previous cleanup of logging. 