### PR TITLE
add engines to gui package.json

### DIFF
--- a/elpis/gui/package.json
+++ b/elpis/gui/package.json
@@ -31,6 +31,9 @@
     "web-vitals": "^1.0.1",
     "xslt3": "^2.1.0"
   },
+  "engines": {
+    "node": "^15"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
This addition will prevent errors when trying to build the GUI with incompatible node version. Currently, trying to install using latest node (v18) will fail due to changes to OpenSSL. These can be worked-around with a recent local node version by adding a flag to the start or build script. 

```
    "build": "react-scripts --openssl-legacy-provider build",
```

But that will break the docker build, which is using node 15, oblivious to the meaning of the flag.  Later, update node in the Dockerfile and check that everything is ok.

