### PR TITLE
Remove Matt Low from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @benfoley @nicklambourne @mattchrlw @harrykeightley @aviraljain99
+*       @benfoley @nicklambourne @harrykeightley @aviraljain99


### PR DESCRIPTION
I believe Matt has retired at this point, we can probably stop pinging him for reviews.

CC: @mattchrlw 