### PR TITLE
Use downloadjs to trigger model zip download

### DIFF
--- a/elpis/endpoints/model.py
+++ b/elpis/endpoints/model.py
@@ -164,8 +164,11 @@ def download():
     shutil.make_archive(
         str(zipped_model_path.parent / zipped_model_path.stem), "zip", model.path / MODEL_PATH
     )
-    logger.info((f"Zipped model created at path: {zipped_model_path}"))
-    return send_file(zipped_model_path, as_attachment=True, cache_timeout=0)
+    logger.info(f"Zipped model created at path: {zipped_model_path}")
+    try:
+        return send_file(zipped_model_path, as_attachment=True, cache_timeout=0)
+    except InterfaceError as e:
+        return jsonify({"status": 500, "error": e.human_message})
 
 
 @bp.route("/upload", methods=["POST"])

--- a/elpis/gui/src/components/Model/DownloadButton.js
+++ b/elpis/gui/src/components/Model/DownloadButton.js
@@ -1,12 +1,17 @@
 import React, {useState} from "react";
 import {Button, Loader, Segment} from "semantic-ui-react";
 import urls from "urls";
+import downloadjs from "downloadjs";
 
 export default function DownloadButton() {
   const [downloading, setDownloading] = useState(false);
   const download_model = async () => {
     setDownloading(true);
-    await fetch(urls.api.model.download);
+
+    let response = await fetch(urls.api.model.download);
+    let blob = await response.blob();
+
+    downloadjs(blob, "model.zip", "application/zip");
     setDownloading(false);
   };
 


### PR DESCRIPTION
When running the code from the hft_model_options PR, model zips were not downloading. Checked in Safari and Chrome.

Wacky, it appears that the model.zip download request response is all fine, just no download. I have added some code to the DownloadButton component, based on what we use for downloading the transcriptions.

Now it downloads as expected