### PR TITLE
Ben hft model options

### DIFF
--- a/elpis/endpoints/model.py
+++ b/elpis/endpoints/model.py
@@ -164,8 +164,11 @@ def download():
     shutil.make_archive(
         str(zipped_model_path.parent / zipped_model_path.stem), "zip", model.path / MODEL_PATH
     )
-    logger.info((f"Zipped model created at path: {zipped_model_path}"))
-    return send_file(zipped_model_path, as_attachment=True, cache_timeout=0)
+    logger.info(f"Zipped model created at path: {zipped_model_path}")
+    try:
+        return send_file(zipped_model_path, as_attachment=True, cache_timeout=0)
+    except InterfaceError as e:
+        return jsonify({"status": 500, "error": e.human_message})
 
 
 @bp.route("/upload", methods=["POST"])

--- a/elpis/endpoints/model.py
+++ b/elpis/endpoints/model.py
@@ -61,8 +61,10 @@ def new():
 def load():
     interface = app.config["INTERFACE"]
     model = interface.get_model(request.json["name"])
-    app.config["CURRENT_DATASET"] = model.dataset
-    app.config["CURRENT_PRON_DICT"] = model.pron_dict
+    if model.dataset:
+        app.config["CURRENT_DATASET"] = model.dataset
+    if model.pron_dict:
+        app.config["CURRENT_PRON_DICT"] = model.pron_dict
     app.config["CURRENT_MODEL"] = model
     data = {"config": model.config._load(), "log": model.log}
     return jsonify({"status": 200, "data": data})
@@ -215,7 +217,6 @@ def upload():
             "name": model["name"],
             "engine_name": model["engine_name"],
             "status": model["status"],
-            "dataset_name": "UPLOADED_MODEL",
         }
         for model in interface.list_models_verbose()
     ]

--- a/elpis/engines/common/objects/interface.py
+++ b/elpis/engines/common/objects/interface.py
@@ -249,7 +249,9 @@ class Interface(FSObject):
             raise InterfaceError(f'Tried to load a model called "{mname}" that does not exist')
         hash_dir = self.config["models"][mname]
         m = self.engine.model.load(self.models_path.joinpath(hash_dir))
-        m.dataset = self.get_dataset(m.config["dataset_name"])
+        logger.info(f"{m.config}")
+        if m.config["dataset_name"] is not None:
+            m.dataset = self.get_dataset(m.config["dataset_name"])
         if m.config["pron_dict_name"] is not None:
             m.pron_dict = self.get_pron_dict(m.config["pron_dict_name"])
         return m

--- a/elpis/gui/src/components/Model/Dashboard.js
+++ b/elpis/gui/src/components/Model/Dashboard.js
@@ -209,12 +209,18 @@ const mapDispatchToProps = dispatch => ({
     },
     modelLoad: (modelData, datasetData, pronDictData) => {
         dispatch(modelLoad(modelData))
-            .then(() => dispatch(datasetLoad(datasetData)))
+            .then(() => {
+                if (datasetData.name) {
+                    return dispatch(datasetLoad(datasetData));
+                } else {
+                    console.log("No dataset to load for this model.");
+                }
+            })
             .then(() => {
                 if (pronDictData.name) {
                     return dispatch(pronDictLoad(pronDictData));
                 } else {
-                    console.log("No pron dict to load for this model");
+                    console.log("No pron dict to load for this model.");
                 }
             });
     },

--- a/elpis/gui/src/components/Model/DownloadButton.js
+++ b/elpis/gui/src/components/Model/DownloadButton.js
@@ -1,12 +1,17 @@
 import React, {useState} from "react";
 import {Button, Loader, Segment} from "semantic-ui-react";
 import urls from "urls";
+import downloadjs from "downloadjs";
 
 export default function DownloadButton() {
   const [downloading, setDownloading] = useState(false);
   const download_model = async () => {
     setDownloading(true);
-    await fetch(urls.api.model.download);
+
+    let response = await fetch(urls.api.model.download);
+    let blob = await response.blob();
+
+    downloadjs(blob, "model.zip", "application/zip");
     setDownloading(false);
   };
 


### PR DESCRIPTION
Uploading a model.zip results in a model in backend state with no dataset or pron dict.  These changes allow the model to show in the Training dashboard and can be safely selectable for transcribing. Previously, selecting an uploaded model would crash as the GUI tried to load a dataset.