### PR TITLE
better handling of dataset name for uploaded models

### DIFF
--- a/elpis/endpoints/model.py
+++ b/elpis/endpoints/model.py
@@ -61,8 +61,10 @@ def new():
 def load():
     interface = app.config["INTERFACE"]
     model = interface.get_model(request.json["name"])
-    app.config["CURRENT_DATASET"] = model.dataset
-    app.config["CURRENT_PRON_DICT"] = model.pron_dict
+    if model.dataset:
+        app.config["CURRENT_DATASET"] = model.dataset
+    if model.pron_dict:
+        app.config["CURRENT_PRON_DICT"] = model.pron_dict
     app.config["CURRENT_MODEL"] = model
     data = {"config": model.config._load(), "log": model.log}
     return jsonify({"status": 200, "data": data})
@@ -215,7 +217,6 @@ def upload():
             "name": model["name"],
             "engine_name": model["engine_name"],
             "status": model["status"],
-            "dataset_name": "UPLOADED_MODEL",
         }
         for model in interface.list_models_verbose()
     ]

--- a/elpis/engines/common/objects/interface.py
+++ b/elpis/engines/common/objects/interface.py
@@ -249,7 +249,9 @@ class Interface(FSObject):
             raise InterfaceError(f'Tried to load a model called "{mname}" that does not exist')
         hash_dir = self.config["models"][mname]
         m = self.engine.model.load(self.models_path.joinpath(hash_dir))
-        m.dataset = self.get_dataset(m.config["dataset_name"])
+        logger.info(f"{m.config}")
+        if m.config["dataset_name"] is not None:
+            m.dataset = self.get_dataset(m.config["dataset_name"])
         if m.config["pron_dict_name"] is not None:
             m.pron_dict = self.get_pron_dict(m.config["pron_dict_name"])
         return m

--- a/elpis/gui/src/components/Model/CurrentModelName.js
+++ b/elpis/gui/src/components/Model/CurrentModelName.js
@@ -26,8 +26,8 @@ class CurrentModelName extends Component {
                                 {t("pronDict.common.currentPronDictLabel") + dictName}
                                 <br />
                             </>
-                    }
-                        {t("dataset.common.currentDatasetLabel") + datasetName}
+                        }
+                        {datasetName && t("dataset.common.currentDatasetLabel") + datasetName}
                     </Message>
                 }
                 {!currentEngine &&

--- a/elpis/gui/src/components/Model/Dashboard.js
+++ b/elpis/gui/src/components/Model/Dashboard.js
@@ -209,12 +209,18 @@ const mapDispatchToProps = dispatch => ({
     },
     modelLoad: (modelData, datasetData, pronDictData) => {
         dispatch(modelLoad(modelData))
-            .then(() => dispatch(datasetLoad(datasetData)))
+            .then(() => {
+                if (datasetData.name) {
+                    return dispatch(datasetLoad(datasetData));
+                } else {
+                    console.log("No dataset to load for this model.");
+                }
+            })
             .then(() => {
                 if (pronDictData.name) {
                     return dispatch(pronDictLoad(pronDictData));
                 } else {
-                    console.log("No pron dict to load for this model");
+                    console.log("No pron dict to load for this model.");
                 }
             });
     },

--- a/elpis/gui/src/components/Transcription/ChooseModel.js
+++ b/elpis/gui/src/components/Transcription/ChooseModel.js
@@ -170,9 +170,13 @@ const mapDispatchToProps = dispatch => ({
     _modelLoad: (modelData, datasetData, engineName, pronDictData) => {
         dispatch(engineLoad(engineName))
             .then(() => dispatch(modelLoad(modelData)))
-            .then(() => dispatch(datasetLoad(datasetData)))
             .then(() => {
-                if (pronDictData) {
+                if (datasetData.name) {
+                    dispatch(datasetLoad(datasetData));
+                }
+            })
+            .then(() => {
+                if (pronDictData.name) {
                     dispatch(pronDictLoad(pronDictData));
                 }
             });

--- a/elpis/gui/src/components/Transcription/New.js
+++ b/elpis/gui/src/components/Transcription/New.js
@@ -299,9 +299,13 @@ const mapDispatchToProps = dispatch => ({
     modelLoad: (modelData, datasetData, engineName, pronDictData) => {
         dispatch(engineLoad(engineName))
             .then(()=> dispatch(modelLoad(modelData)))
-            .then(() => dispatch(datasetLoad(datasetData)))
             .then(() => {
-                if (pronDictData && pronDictData["name"]) {
+                if (datasetData.name) {
+                    dispatch(datasetLoad(datasetData));
+                }
+            })
+            .then(() => {
+                if (pronDictData.name) {
                     dispatch(pronDictLoad(pronDictData));
                 }
             });


### PR DESCRIPTION
When a model is uploaded, pron_dict_name and dataset_name will be null. This was causing problems with the GUI trying to load a dataset that it didn't know the name for.  This fix also allows an uploaded dataset to show on the training dashboard, and can be selected, activating it for transcription. 