### PR TITLE
add engine name to choose model page

### DIFF
--- a/elpis/gui/src/components/Transcription/ChooseModel.js
+++ b/elpis/gui/src/components/Transcription/ChooseModel.js
@@ -68,6 +68,7 @@ class ChooseModel extends Component {
             return (
                 <Button key={index} onClick={() => this.handleSelectModel(model.name)}>
                     {model.name}
+                    <span className="engine-name">({model.engine_name})</span>
                 </Button>
             );
         });

--- a/elpis/gui/src/index.css
+++ b/elpis/gui/src/index.css
@@ -347,3 +347,8 @@ label.pad-right,
 .ui.toggle.checkbox .box:before, .ui.toggle.checkbox label:before {
     background-color: grey;
 }
+
+.engine-name {
+    font-style: italic;
+    margin-left: 0.5em;
+}


### PR DESCRIPTION
Include the engine name with each model. 

<img width="657" alt="engine_name" src="https://user-images.githubusercontent.com/5652120/196062976-709d619b-2bf8-4b47-8812-e55144f7608e.png">

Closes #306 